### PR TITLE
feat: Import cms signals handler module in order to register receivers

### DIFF
--- a/eox_nelp/apps.py
+++ b/eox_nelp/apps.py
@@ -31,6 +31,13 @@ class EoxNelpConfig(AppConfig):
         }
     }
 
+    def ready(self):
+        """
+        Method to perform actions after apps registry is ended.
+        """
+        # This is required in order to register the receiver inside handlers module.
+        from cms.djangoapps.contentstore.signals import handlers  # pylint: disable=unused-import
+
 
 class EoxNelpCMSConfig(AppConfig):
     """App configuration"""


### PR DESCRIPTION
## Description
When a course is deleted in the lms service the elasticsearch record is not deleted since that operation is performed by this method https://github.com/openedx/edx-platform/blob/open-release/maple.master/cms/djangoapps/contentstore/signals/handlers.py#L73 which is triggered by a signal however that receiver method is  not register because that belongs to the cms service. This change import the handler module in order to force the method registration.