### PR TITLE
Jlc/mfe config api nelp

### DIFF
--- a/eox_nelp/apps.py
+++ b/eox_nelp/apps.py
@@ -45,13 +45,6 @@ class EoxNelpCMSConfig(AppConfig):
     verbose_name = "Nelp Openedx Extensions"
 
     plugin_app = {
-        'url_config': {
-            'cms.djangoapp': {
-                'namespace': 'eox-nelp',
-                'regex': r'^eox-nelp/',
-                'relative_path': 'urls',
-            }
-        },
         'settings_config': {
             'cms.djangoapp': {
                 'test': {'relative_path': 'settings.test'},

--- a/eox_nelp/edxapp_wrapper/backends/mfe_config_view_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/mfe_config_view_m_v1.py
@@ -1,0 +1,16 @@
+"""Backend for mfe_config view.
+
+This file contains all the necessary dependencies from
+https://github.com/edx/edx-platform/tree/master/lms/djangoapps/mfe_config_api
+"""
+from lms.djangoapps.mfe_config_api.views import MFEConfigView
+
+
+def get_MFE_config_view():
+    """Allow to get the mfe_config view class  from
+    https://github.com/edx/edx-platform/tree/master/lms/djangoapps/mfe_config_api/views.py
+
+    Returns:
+        helpers module.
+    """
+    return MFEConfigView

--- a/eox_nelp/edxapp_wrapper/mfe_config_view.py
+++ b/eox_nelp/edxapp_wrapper/mfe_config_view.py
@@ -1,0 +1,16 @@
+"""
+Wrapper mfe_config api view.
+
+This contains  the required api view from mfe_config
+
+Attributes:
+    backend:Imported site_configuration module by using the plugin settings.
+    MFEConfigView: Wrapper mfe_config  api view class.
+"""
+from importlib import import_module
+
+from django.conf import settings
+
+mfe_config_view = import_module(settings.EOX_NELP_MFE_CONFIG_VIEW)
+
+MFEConfigView = mfe_config_view.get_MFE_config_view()

--- a/eox_nelp/settings/common.py
+++ b/eox_nelp/settings/common.py
@@ -28,6 +28,7 @@ def plugin_settings(settings):
     settings.EOX_NELP_SITE_CONFIGURATION = 'eox_nelp.edxapp_wrapper.backends.site_configuration_m_v1'
     settings.EOX_NELP_USER_API = 'eox_nelp.edxapp_wrapper.backends.user_api_m_v1'
     settings.EOX_NELP_USER_AUTHN = 'eox_nelp.edxapp_wrapper.backends.user_authn_m_v1'
+    settings.EOX_NELP_MFE_CONFIG_VIEW = 'eox_nelp.edxapp_wrapper.backends.mfe_config_view_m_v1'
 
     if find_spec('eox_audit_model') and EOX_AUDIT_MODEL_APP not in settings.INSTALLED_APPS:
         settings.INSTALLED_APPS.append(EOX_AUDIT_MODEL_APP)

--- a/eox_nelp/urls.py
+++ b/eox_nelp/urls.py
@@ -22,4 +22,5 @@ app_name = 'eox_nelp'  # pylint: disable=invalid-name
 urlpatterns = [  # pylint: disable=invalid-name
     url(r'^eox-info$', views.info_view),
     url(r'^courses/', include('eox_nelp.course_api.urls')),
+    url(r'^api/mfe_config/v1/', views.NelpMFEConfigView.as_view(), name='nelp_config'),
 ]

--- a/eox_nelp/views.py
+++ b/eox_nelp/views.py
@@ -8,9 +8,12 @@ from os.path import dirname, realpath
 from subprocess import CalledProcessError, check_output
 
 import six
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
+from eox_theming.configuration import ThemingConfiguration as theming
+from rest_framework import status
 
 import eox_nelp
+from eox_nelp.edxapp_wrapper.mfe_config_view import MFEConfigView
 
 
 def info_view(request):
@@ -34,3 +37,30 @@ def info_view(request):
         json.dumps(response_data),
         content_type="application/json"
     )
+
+
+class NelpMFEConfigView(MFEConfigView):
+    """
+    Provides an API endpoint to get the MFE_CONFIG from site configuration with
+    nelp extra fields.
+    """
+
+    def get(self, request):
+        """
+        Return the MFE configuration by NELP(adding custom nelp fields).
+        """
+        base_get_response = super().get(request)
+
+        if base_get_response.status_code != 200:
+            return base_get_response
+
+        mfe_config_dict = json.loads(base_get_response.content)
+        theme_options = theming.options('THEME_OPTIONS')
+        interactive_color = theming.options('interactive_color')
+        theme_additions = {
+            'THEME_OPTIONS': theme_options,
+            'pgn-color-primary-base': interactive_color,
+        }
+        mfe_config_dict.update(theme_additions)
+
+        return JsonResponse(mfe_config_dict, status=status.HTTP_200_OK)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,3 +3,4 @@
 
 Django
 eox-tenant
+eox-theming


### PR DESCRIPTION
# Description

Add eox-nelp flavour of mfe config api.
this add to the MFE-CONFIG response two changes : 
- all the `THEMING_OPTIONS` object 
-  the `interactive_color` nested in the form: CUSTOM_PRIMARY_COLOR': {'primary': interactive_color},`

## Before 

![image](https://user-images.githubusercontent.com/51926076/217073973-d9dfd190-fee7-4a5b-9b95-9a4cd823dd69.png)

## After
![image](https://user-images.githubusercontent.com/51926076/217074488-d6e5983d-f364-4c9a-895c-22d42c7335ad.png)

### gif comparison
![Peek 2023-02-06 15-02](https://user-images.githubusercontent.com/51926076/217073997-eb0904ea-b2f7-432b-9768-24eb96e2a35c.gif)

# BreakChanges:

- This removes the studio entry for eox-nelp due lms config API is activated  only in the lms.
- from now the package also depends on eox-theming. 