### PR TITLE
feat: change nesting  of `pgn-color-primary-base`

### DIFF
--- a/eox_nelp/views.py
+++ b/eox_nelp/views.py
@@ -59,7 +59,7 @@ class NelpMFEConfigView(MFEConfigView):
         interactive_color = theming.options('interactive_color')
         theme_additions = {
             'THEME_OPTIONS': theme_options,
-            'pgn-color-primary-base': interactive_color,
+            'CUSTOM_PRIMARY_COLORS': {'pgn-color-primary-base': interactive_color},
         }
         mfe_config_dict.update(theme_additions)
 


### PR DESCRIPTION
# Description 
change the form in mfe config view of `pgn-color-primary-base`.

## Before
![image](https://user-images.githubusercontent.com/51926076/217280618-93437f52-78e9-4bd2-966e-42fe8243f8e0.png)

## After 
![2023-02-07_13-57](https://user-images.githubusercontent.com/51926076/217339952-413c5dea-027a-4324-a754-02774f20fe49.png)

