### PR TITLE
feat: add map_mfe_config_keys implementation

### DIFF
--- a/eox_nelp/views.py
+++ b/eox_nelp/views.py
@@ -8,6 +8,7 @@ from os.path import dirname, realpath
 from subprocess import CalledProcessError, check_output
 
 import six
+from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 from eox_theming.configuration import ThemingConfiguration as theming
 from rest_framework import status
@@ -62,5 +63,12 @@ class NelpMFEConfigView(MFEConfigView):
             'CUSTOM_PRIMARY_COLORS': {'pgn-color-primary-base': interactive_color},
         }
         mfe_config_dict.update(theme_additions)
+
+        mfe_config_map = getattr(settings, "MFE_CONFIG_MAP", {})
+        mfe_config_map_additions = {
+            mfe_config_key: getattr(settings, setting_key, None)
+            for (setting_key, mfe_config_key) in mfe_config_map.items()
+        }
+        mfe_config_dict.update(mfe_config_map_additions)
 
         return JsonResponse(mfe_config_dict, status=status.HTTP_200_OK)


### PR DESCRIPTION
# Description

Add mfe config map keys object `MAP_MFE_CONFIG_KEYS` .  With this mapping  the mfe config API will respond wit they key of the mapping `KEY_MFE_JS` and the value found in Django setting with the `KEY_SETTING_DJANGO`.
This only works for keys in the main level of the Django settings.
This is based on the following map:
``` js
MFE_CONFIG_MAP: {
"KEY_SETTING_DJANGO": "KEY_MFE_JS",
}
```
eg: 
``` js
    "MFE_CONFIG_MAP": {
        "favicon_path": "FAVICON_URL",
        "logo_image_url": "LOGO_URL"
    },
```

## Functionality 2
![Peek 2023-02-13 12-25](https://user-images.githubusercontent.com/51926076/218528740-81aec7b9-72a2-4a9f-a3c7-c257cde3a855.gif)


