### PR TITLE
Jlc/control progress event by settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ quality: clean install-test-reqs## check coding style with pycodestyle and pylin
 
 python-test: clean install-test-reqs## Run test suite.
 	$(TOX) coverage run --source ./eox_nelp manage.py test
-	$(TOX) coverage report -m --fail-under=92
+	$(TOX) coverage report -m --fail-under=93
 
 complexity: clean install-test-reqs## Run complexity suite with flake8.
 	$(TOX) flake8  --max-complexity 10 eox_nelp

--- a/eox_nelp/signals/tasks.py
+++ b/eox_nelp/signals/tasks.py
@@ -7,6 +7,7 @@ tasks:
 import logging
 
 from celery import shared_task
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models import Q
 from eox_core.edxapp_wrapper.courseware import get_courseware_courses
@@ -45,6 +46,9 @@ def dispatch_futurex_progress(course_id, user_id, is_complete=None):
         user_id (str): User identifier.
         is_complete (bool): Determines is that hast complete the course
     """
+    if not getattr(settings, "ACTIVATE_DISPATCH_FUTUREX_PROGRESS", False):
+        return
+
     user = User.objects.get(id=user_id)
     user_has_passing_grade = is_complete if is_complete is not None else _user_has_passing_grade(user, course_id)
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

Now you can manage the activation of the progress event to send to
futurex with the field `ACTIVATE_DISPATCH_FUTUREX_PROGRESS` in settings or tenant config.

Useful information to include:
- Added test for the setting activation.
- Remove a warning for multiple registers of a model with `create_test_model`. d8a62571e4f3d9dbc0d17409b537b76b41163e03
- Dont forget to configure appropriate `EOX_MAX_CONFIG_OVERRIDE_SECONDS`

## Testing instructions
Set the setting `ACTIVATE_DISPATCH_FUTUREX_PROGRESS` and check in worker or eager the activation of the event.


### After
**Without the setting**
![Peek 2023-03-28 18-21](https://user-images.githubusercontent.com/51926076/228389879-cbf33c82-61d3-4ee3-841d-6d72dc27657c.gif)

**with the setting**

![Peek 2023-03-28 18-28](https://user-images.githubusercontent.com/51926076/228390073-377dec7c-3c18-4f96-b3ae-972d1babbb1d.gif)
#### Stage test
![Peek 2023-03-29 16-03](https://user-images.githubusercontent.com/51926076/228668624-376adde8-ec3a-4739-ab83-78f3f239cbb2.gif)
## Additional information


Include anything else that will help reviewers and consumers understand the change.
- This extends the PR https://github.com/eduNEXT/eox-nelp/pull/40
- Jira story:
https://edunext.atlassian.net/browse/FUTUREX-371


## Checklist for Merge

- [x] Tested in a remote environment
- [x] Updated documentation
- [x] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
