### PR TITLE
feat: add notification receiver, this allows to create UpcomingCourse…

### DIFF
--- a/eox_nelp/apps.py
+++ b/eox_nelp/apps.py
@@ -72,4 +72,16 @@ class EoxNelpCMSConfig(AppConfig):
                 'devstack': {'relative_path': 'settings.devstack'},
             },
         },
+        'signals_config': {
+            'cms.djangoapp': {
+                'relative_path': 'signals.receivers',
+                'receivers': [
+                    {
+                        'receiver_func_name': 'create_course_notifications',
+                        'signal_path': 'eox_nelp.edxapp_wrapper.modulestore.course_published',
+                        'dispatch_uid': 'create_course_notifications_receiver',
+                    },
+                ],
+            },
+        },
     }

--- a/eox_nelp/edxapp_wrapper/backends/modulestore_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/modulestore_m_v1.py
@@ -1,0 +1,26 @@
+"""Backend for xmodule.modulestore app.
+
+This file contains all the necessary dependencies from
+https://github.com/eduNEXT/edunext-platform/blob/master/common/lib/xmodule/xmodule/modulestore
+"""
+from xmodule.modulestore.django import SignalHandler, modulestore  # pylint: disable=import-error
+
+
+def get_modulestore():
+    """Allow to get modulestore function from
+    https://github.com/eduNEXT/edunext-platform/blob/master/common/lib/xmodule/xmodule/modulestore/django.py#L311
+
+    Returns:
+        modulestore function.
+    """
+    return modulestore
+
+
+def get_course_published_signal():
+    """Allow to get the course_published from
+    https://github.com/eduNEXT/edunext-platform/blob/master/common/lib/xmodule/xmodule/modulestore/django.py#L167
+
+    Returns:
+        course_published SwitchedSignal.
+    """
+    return SignalHandler.course_published

--- a/eox_nelp/edxapp_wrapper/modulestore.py
+++ b/eox_nelp/edxapp_wrapper/modulestore.py
@@ -1,0 +1,18 @@
+"""
+Wrapper xmodule.modulestore module.
+
+This contains all the required dependencies from modulestore
+
+Attributes:
+    backend:Imported module by using the plugin settings.
+    CourseCreator: Wrapper CourseCreator model.
+    CourseCreatorAdmin: Wrapper CourseCreatorAdmin class.
+"""
+from importlib import import_module
+
+from django.conf import settings
+
+backend = import_module(settings.EOX_NELP_XMODULE_MODULESTORE)
+
+modulestore = backend.get_modulestore()
+course_published = backend.get_course_published_signal()

--- a/eox_nelp/edxapp_wrapper/test_backends/modulestore_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/modulestore_m_v1.py
@@ -1,0 +1,20 @@
+"""Test backend for xmodule.modulestore app."""
+from mock import Mock
+
+
+def get_modulestore():
+    """Test backend for eox_nelp.edxapp_wrapper.backends.modulestore_m_v1.
+
+    Returns:
+        Mock class.
+    """
+    return Mock()
+
+
+def get_course_published_signal():
+    """Test backend for eox_nelp.edxapp_wrapper.backends.modulestore_m_v1.
+
+    Returns:
+        Mock class.
+    """
+    return Mock()

--- a/eox_nelp/notifications/models.py
+++ b/eox_nelp/notifications/models.py
@@ -1,5 +1,4 @@
-"""
-Notifications models. This contains all models related with the notification.
+"""Notifications models. This contains all models related with the notification.
 
 Models:
     UpcomingCourseDueDate: Model that sends notifications based on the subsection stored data.

--- a/eox_nelp/notifications/tasks.py
+++ b/eox_nelp/notifications/tasks.py
@@ -1,0 +1,89 @@
+"""Notification tasks. Contains all tasks related with the notifications features.
+
+tasks:
+    create_course_notifications: Creates UpcomingCourseDueDate records based on due dates.
+"""
+import datetime
+
+from celery import shared_task
+from django.utils import timezone
+from opaque_keys.edx.keys import CourseKey
+
+from eox_nelp.edxapp_wrapper.modulestore import modulestore
+from eox_nelp.notifications.models import UpcomingCourseDueDate
+
+
+@shared_task
+def create_course_notifications(course_id):
+    """Creates UpcomingCourseDueDate records based on due dates. This considers the following rules:
+
+        1. The course must have the notification feature active, add the following dict to other_course_settings
+           to do that.
+
+            {
+                "notifications": {
+                    "active": true,
+                    "days_in_advance": [
+                        1,
+                        2,
+                        3
+                    ]
+                }
+            }
+
+        2. If days_in_advance is not set, the default value will be [7]
+        3. If the subsection doesn't have a due date, nothing will happen.
+        4. If the subsection already has UpcomingCourseDuedates records and they has not been sent, they will be
+           deleted.
+        5. If the subsection already has UpcomingCourseDuedates records and they has been sent, this will preserve
+           that data to keep a register.
+        6. If the notification date is in the past, the record won't be created.
+
+    Args:
+        course_id (str): Unique course identifier.
+    """
+    course_key = CourseKey.from_string(course_id)
+    course = modulestore().get_course(course_key)
+
+    notifications = course.other_course_settings.get("notifications", {})
+
+    if not notifications.get("active"):
+        return
+
+    now = timezone.now()
+    days_in_advance = notifications.get("days_in_advance")
+
+    if not days_in_advance:
+        days_in_advance = [7]
+
+    if not isinstance(days_in_advance, list):
+        days_in_advance = [days_in_advance]
+
+    sub_sections = modulestore().get_items(course_key, qualifiers={"category": "sequential"})
+
+    for sub_section in sub_sections:
+        created_or_updated = []
+        due_date = sub_section.due
+
+        if not due_date:
+            continue
+
+        for day in days_in_advance:
+            notification_date = due_date - datetime.timedelta(days=int(day))
+
+            if notification_date < now:
+                continue
+
+            obj, _ = UpcomingCourseDueDate.objects.update_or_create(  # pylint: disable=no-member
+                course_id=course_id,
+                location_id=sub_section.location,
+                notification_date=notification_date,
+                defaults={"due_date": due_date, "notification_date": notification_date},
+            )
+            created_or_updated.append(obj.id)
+
+        UpcomingCourseDueDate.objects.exclude(id__in=created_or_updated).filter(  # pylint: disable=no-member
+            course_id=course_id,
+            location_id=sub_section.location,
+            sent=False,
+        ).delete()

--- a/eox_nelp/notifications/tests/test_tasks.py
+++ b/eox_nelp/notifications/tests/test_tasks.py
@@ -1,0 +1,376 @@
+"""This file contains all the test for notifications/models.py file.
+
+Classes:
+    UpcomingCourseDueDateTestCase: Test UpcomingCourseDueDate django model.
+"""
+import datetime
+import unittest
+
+from ddt import data, ddt
+from django.utils import timezone
+from mock import Mock
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from eox_nelp.edxapp_wrapper.modulestore import modulestore
+from eox_nelp.notifications.models import UpcomingCourseDueDate
+from eox_nelp.notifications.tasks import create_course_notifications
+
+
+@ddt
+class CreateCourseNotificationsTestCase(unittest.TestCase):
+    """Test class for function create_course_notifications."""
+
+    def setUp(self):
+        """ Set common conditions for test cases."""
+        self.course = Mock()
+        self.course_id = "course-v1:test+Cx105+2022_T4"
+        modulestore.return_value.get_course.return_value = self.course
+
+    def tearDown(self):
+        """Restore mocks' state"""
+        modulestore.reset_mock()
+        self.course.reset_mock()
+
+    def test_invalid_course_id(self):
+        """Test when the course_id parameter is invalid
+
+        Expected behavior:
+            - Raise InvalidKeyError .
+        """
+        course_id = "This is not Valid"
+
+        self.assertRaises(InvalidKeyError, create_course_notifications, course_id)
+
+    def test_empty_notifications_settings(self):
+        """Test a course that has not been set with notifications
+
+        Expected behavior:
+            - Get items (subsections) has not been called.
+            - There are no new UpcomingCourseDueDate records.
+        """
+        self.course.other_course_settings = {}
+        current_records = list(
+            UpcomingCourseDueDate.objects.all().values_list("id", flat=True)  # pylint: disable=no-member
+        )
+
+        create_course_notifications(course_id=self.course_id)
+
+        modulestore.return_value.get_items.assert_not_called()
+        self.assertEqual(
+            current_records,
+            list(UpcomingCourseDueDate.objects.all().values_list("id", flat=True)),  # pylint: disable=no-member
+        )
+
+    @data(False, None, "", 0)
+    def test_invalid_active_field(self, active_value):
+        """Test a course with invalid active notifications value.
+
+        Expected behavior:
+            - Get items (subsections) has not been called.
+            - There are no new UpcomingCourseDueDate records.
+        """
+        self.course.other_course_settings = {
+            "notifications": {
+                "active": active_value
+            }
+        }
+        current_records = list(
+            UpcomingCourseDueDate.objects.all().values_list("id", flat=True)  # pylint: disable=no-member
+        )
+
+        create_course_notifications(course_id=self.course_id)
+
+        modulestore.return_value.get_items.assert_not_called()
+        self.assertEqual(
+            current_records,
+            list(UpcomingCourseDueDate.objects.all().values_list("id", flat=True)),  # pylint: disable=no-member
+        )
+
+    @data(True, "valid", 1)
+    def test_empty_subsections(self, active_value):
+        """Test a course without subsections.
+
+        Expected behavior:
+            - Get items (subsections) was called with the right parameters.
+            - There are no new UpcomingCourseDueDate records.
+        """
+        self.course.other_course_settings = {
+            "notifications": {
+                "active": active_value
+            }
+        }
+        course_key = CourseKey.from_string(self.course_id)
+        modulestore.return_value.get_items.return_value = self._generate_subsections([])
+        current_records = list(
+            UpcomingCourseDueDate.objects.all().values_list("id", flat=True)  # pylint: disable=no-member
+        )
+
+        create_course_notifications(course_id=self.course_id)
+
+        modulestore.return_value.get_items.assert_called_once_with(
+            course_key,
+            qualifiers={"category": "sequential"},
+        )
+        self.assertEqual(
+            current_records,
+            list(UpcomingCourseDueDate.objects.all().values_list("id", flat=True)),  # pylint: disable=no-member
+        )
+
+    @data(True, "valid", 1)
+    def test_subsections_without_due_date(self, active_value):
+        """Test a course with subsections but the subsections doesn't have due date.
+
+        Expected behavior:
+            - Get items (subsections) was called with the right parameters.
+            - There are no new UpcomingCourseDueDate records.
+        """
+        self.course.other_course_settings = {
+            "notifications": {
+                "active": active_value
+            }
+        }
+        course_key = CourseKey.from_string(self.course_id)
+        modulestore.return_value.get_items.return_value = self._generate_subsections(
+            [{"due": None}, {"due": None}]
+        )
+        current_records = list(
+            UpcomingCourseDueDate.objects.all().values_list("id", flat=True)  # pylint: disable=no-member
+        )
+
+        create_course_notifications(course_id=self.course_id)
+
+        modulestore.return_value.get_items.assert_called_once_with(
+            course_key,
+            qualifiers={"category": "sequential"},
+        )
+        self.assertEqual(
+            current_records,
+            list(UpcomingCourseDueDate.objects.all().values_list("id", flat=True)),  # pylint: disable=no-member
+        )
+
+    @data(True, "valid", 1)
+    def test_create_multiple_notifications(self, active_value):
+        """Test a course with two subsections with due date
+
+        Expected behavior:
+            - Get items (subsections) was called with the right parameters.
+            - Two new UpcomingCourseDueDate records were created.
+        """
+        self.course.other_course_settings = {
+            "notifications": {
+                "active": active_value
+            }
+        }
+        due_date = timezone.now() + datetime.timedelta(days=18)
+        expected_notification_date = due_date - datetime.timedelta(days=7)
+        course_key = CourseKey.from_string(self.course_id)
+        location_1 = "block-v1:test+CS501+2022_T4+type@sequential+block@a54730a9b89f420a8d0343dd581b447a"
+        location_2 = "block-v1:test+CS501+2022_T4+type@sequential+block@ww47308785454564646343dd581b4rrr"
+        modulestore.return_value.get_items.return_value = self._generate_subsections(
+            [
+                {
+                    "due": due_date,
+                    "location": location_1
+                },
+                {
+                    "due": due_date,
+                    "location": location_2
+                },
+            ]
+        )
+
+        create_course_notifications(course_id=self.course_id)
+
+        modulestore.return_value.get_items.assert_called_once_with(
+            course_key,
+            qualifiers={"category": "sequential"},
+        )
+        for location in [location_1, location_2]:
+            self.assertTrue(
+                UpcomingCourseDueDate.objects.get(  # pylint: disable=no-member
+                    course_id=self.course_id,
+                    location_id=location,
+                    due_date=due_date,
+                    notification_date=expected_notification_date,
+                )
+            )
+
+    @data(True, "valid", 1)
+    def test_past_notification_date(self, active_value):
+        """Test a course with a subsection which have a nearly due_date
+        therefore the notification date is in the past
+
+        Expected behavior:
+            - Get items (subsections) was called with the right parameters.
+            - There are no new UpcomingCourseDueDate records.
+        """
+        self.course.other_course_settings = {
+            "notifications": {
+                "active": active_value
+            }
+        }
+        due_date = timezone.now()
+        expected_notification_date = due_date - datetime.timedelta(days=7)
+        course_key = CourseKey.from_string(self.course_id)
+        location = "block-v1:test+CS501+2022_T4+type@sequential+block@a54730a9b89f420a8d0343dd581b447a"
+        modulestore.return_value.get_items.return_value = self._generate_subsections(
+            [
+                {
+                    "due": due_date,
+                    "location": location
+                },
+            ]
+        )
+
+        create_course_notifications(course_id=self.course_id)
+
+        modulestore.return_value.get_items.assert_called_once_with(
+            course_key,
+            qualifiers={"category": "sequential"},
+        )
+        self.assertFalse(
+            UpcomingCourseDueDate.objects.filter(  # pylint: disable=no-member
+                course_id=self.course_id,
+                location_id=location,
+                due_date=due_date,
+                notification_date=expected_notification_date,
+            )
+        )
+
+    @data(True, "valid", 1)
+    def test_update_notification(self, active_value):
+        """Test when there is already a UpcomingCourseDueDate record, but the due date changed.
+
+        Expected behavior:
+            - Get items (subsections) was called with the right parameters.
+            - A new UpcomingCourseDueDate record is created.
+            - Previous UpcomingCourseDueDate record is deleted.
+        """
+        self.course.other_course_settings = {
+            "notifications": {
+                "active": active_value
+            }
+        }
+        location = "block-v1:test+CS501+2022_T4+type@sequential+block@a54730a9b89f420a8d0343dd581b447a"
+        due_date = timezone.now()
+        # Create old record
+        UpcomingCourseDueDate.objects.create(  # pylint: disable=no-member
+            course_id=self.course_id,
+            location_id=location,
+            due_date=due_date,
+            notification_date=due_date,
+        )
+        new_due_date = timezone.now() + datetime.timedelta(days=18)
+        expected_notification_date = new_due_date - datetime.timedelta(days=7)
+        course_key = CourseKey.from_string(self.course_id)
+        modulestore.return_value.get_items.return_value = self._generate_subsections(
+            [
+                {
+                    "due": new_due_date,
+                    "location": location
+                },
+            ]
+        )
+
+        create_course_notifications(course_id=self.course_id)
+
+        modulestore.return_value.get_items.assert_called_once_with(
+            course_key,
+            qualifiers={"category": "sequential"},
+        )
+        self.assertTrue(
+            UpcomingCourseDueDate.objects.filter(  # pylint: disable=no-member
+                course_id=self.course_id,
+                location_id=location,
+                due_date=new_due_date,
+                notification_date=expected_notification_date,
+            )
+        )
+        self.assertFalse(
+            UpcomingCourseDueDate.objects.filter(  # pylint: disable=no-member
+                course_id=self.course_id,
+                location_id=location,
+                due_date=due_date,
+                notification_date=due_date,
+            )
+        )
+
+    @data("5", 5, [5], [5, 8], [5, "3"])
+    def test_days_in_advance(self, days_in_advance):
+        """Test multiple configuration for days_in_advance.
+
+        Expected behavior:
+            - Get items (subsections) was called with the right parameters.
+            - The number of new UpcomingCourseDueDate records correspond to the number of days in advance.
+        """
+        self.course.other_course_settings = {
+            "notifications": {
+                "active": True,
+                "days_in_advance": days_in_advance
+            }
+        }
+        location = "block-v1:test+CS501+2022_T4+type@sequential+block@a54730a9b89f420a8d0343dd581b447a"
+        due_date = timezone.now() + datetime.timedelta(days=18)
+        course_key = CourseKey.from_string(self.course_id)
+        modulestore.return_value.get_items.return_value = self._generate_subsections(
+            [
+                {
+                    "due": due_date,
+                    "location": location
+                },
+            ]
+        )
+
+        if not isinstance(days_in_advance, list):
+            days_in_advance = [days_in_advance]
+
+        create_course_notifications(course_id=self.course_id)
+
+        modulestore.return_value.get_items.assert_called_once_with(
+            course_key,
+            qualifiers={"category": "sequential"},
+        )
+
+        for day_in_advance in days_in_advance:
+            self.assertTrue(
+                UpcomingCourseDueDate.objects.filter(  # pylint: disable=no-member
+                    course_id=self.course_id,
+                    location_id=location,
+                    due_date=due_date,
+                    notification_date=due_date - datetime.timedelta(days=int(day_in_advance)),
+                )
+            )
+
+    def _generate_subsections(self, subsections_data):
+        """Helper method to create Mock subsection based on the given data.
+
+        Args:
+            subsections_data: This should be a list of dicts with the following structure:
+
+            [
+                {
+                    "due": due_date,
+                    "location": location
+                },
+                {
+                    "due": due_date,
+                    "location": location
+                },
+                ...
+            ]
+            Every dictionary should contain the subsection data.
+
+        Returns:
+            List of mocks.
+        """
+        subsections = []
+
+        for subsection_data in subsections_data:
+            subsection = Mock()
+            subsection.due = subsection_data.get("due")
+            subsection.location = subsection_data.get("location")
+
+            subsections.append(subsection)
+
+        return subsections

--- a/eox_nelp/settings/common.py
+++ b/eox_nelp/settings/common.py
@@ -28,6 +28,7 @@ def plugin_settings(settings):
     settings.EOX_NELP_USER_AUTHN = 'eox_nelp.edxapp_wrapper.backends.user_authn_m_v1'
     settings.EOX_NELP_MFE_CONFIG_VIEW = 'eox_nelp.edxapp_wrapper.backends.mfe_config_view_m_v1'
     settings.EOX_NELP_COURSE_API = 'eox_nelp.edxapp_wrapper.backends.course_api_m_v1'
+    settings.EOX_NELP_XMODULE_MODULESTORE = 'eox_nelp.edxapp_wrapper.backends.modulestore_m_v1'
 
     settings.FUTUREX_API_URL = 'https://testing-site.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -21,6 +21,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.EOX_NELP_USER_AUTHN = 'eox_nelp.edxapp_wrapper.test_backends.user_authn_m_v1'
     settings.EOX_NELP_MFE_CONFIG_VIEW = 'eox_nelp.edxapp_wrapper.test_backends.mfe_config_view_m_v1'
     settings.EOX_NELP_COURSE_API = 'eox_nelp.edxapp_wrapper.test_backends.course_api_m_v1'
+    settings.EOX_NELP_XMODULE_MODULESTORE = 'eox_nelp.edxapp_wrapper.test_backends.modulestore_m_v1'
 
     settings.FUTUREX_API_URL = 'https://testing.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'

--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -6,6 +6,7 @@ Functions:
     block_completion_progress_publisher: it will publish the user progress based on post_save signal.
     course_grade_changed_progress_publisher: it will publish the user progress based on COURSE_GRADE_CHANGED signal.
 """
+from eox_nelp.notifications.tasks import create_course_notifications as create_course_notifications_task
 from eox_nelp.signals.tasks import dispatch_futurex_progress
 
 
@@ -41,3 +42,14 @@ def course_grade_changed_progress_publisher(
         user_id=user.id,
         is_complete=course_grade.passed,
     )
+
+
+def create_course_notifications(course_key, **kwargs):  # pylint: disable=unused-argument
+    """This receiver is connected to the course_published signal, that belong to
+    the class SignalHandler from xmodule, and this will create upcoming notifications
+    based on the sub-section due dates.
+
+    Args:
+        course_key<CourseLocator>: Opaque keys locator used to identify a course.
+    """
+    create_course_notifications_task.delay(course_id=str(course_key))


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This address this [issue](https://edunext.atlassian.net/browse/FUTUREX-395)

## Testing instructions
1. Go to studio  and set other course settings

Example:

```
{
    "notifications": {
        "active": true,
        "days_in_advance": [
            1,
            2,
            3
        ]
    }
}
```

2. Go to the outline and set any subsebtion due date
![image](https://user-images.githubusercontent.com/36200299/232921766-9d64a2b8-a26e-45c2-aa5c-1c67b2560283.png)

3. Save course
4. Verify in admin panel `/admin/eox_nelp/upcomingcourseduedate/`

Check this [doc-string](https://github.com/eduNEXT/eox-nelp/blob/and/add_notification_receiver/eox_nelp/notifications/tasks.py#L19) to get more details

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
