### PR TITLE
chore: add more manipulation for subsection_due_date

### DIFF
--- a/eox_nelp/notifications/notify_course_due_date.py
+++ b/eox_nelp/notifications/notify_course_due_date.py
@@ -74,7 +74,7 @@ def generate_email_messages(subsection_xblock, course_xblock):
     email_context = get_course_email_context(course_xblock)
     email_context["subsection_title"] = subsection_xblock.display_name
     email_context["subsection_delta"] = subsection_xblock.due - timezone.now()
-    email_context["subsection_due_date"] = str(subsection_xblock.due)
+    email_context["subsection_due_date"] = subsection_xblock.due
 
     return {
         "subject": settings.FUTUREX_NOTIFY_SUBSECTION_SUBJECT_MESSAGE.format(**email_context),


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

Looking at this comment, I thing is useful the ability to use the properties of the DateTime object of `subsection_due_date` in the templates.
https://github.com/nelc/edunext-nelp-documentation/pull/5/files#r1183917662


![image](https://user-images.githubusercontent.com/51926076/235987430-76c924c3-2bd4-4a5c-a4a4-a0bb5027a6ae.png)


