### PR TITLE
feat!: use explicit stats' query params

### DIFF
--- a/eox_nelp/stats/templates/tenant_stats.html
+++ b/eox_nelp/stats/templates/tenant_stats.html
@@ -8,11 +8,11 @@
 <body>
     <div id="tenant-stats"></div>
     <script>
-      var showVideos = "true" === "${videos}";
-      var showCourses = "true" === "${courses}";
-      var showProblems = "true" === "${problems}";
-      var showLearners = "true" === "${learners}";
-      var showInstructors = "true" === "${instructors}";
+      var showVideos = "false" === "${hideVideos}";
+      var showCourses = "false" === "${hideCourses}";
+      var showProblems = "false" === "${hideProblems}";
+      var showLearners = "false" === "${hideLearners}";
+      var showInstructors = "false" === "${hideInstructors}";
     </script>
     <script src="${static.url('tenant_stats/js/tenant_stats.js')}"></script>
 </body>

--- a/eox_nelp/stats/tests/test_views.py
+++ b/eox_nelp/stats/tests/test_views.py
@@ -37,26 +37,26 @@ class GetTenantStatsTestCase(TestCase):
         self.assertEqual(self.template_name, response.templates[0].name)
         self.assertContains(response, '<div id="tenant-stats"></div')
 
-    @data("videos", "courses", "problems", "instructors", "learners")
-    def test_filter_specific_stat(self, query_param):
+    @data("hideVideos", "hideCourses", "hideProblems", "hideInstructors", "hideLearners")
+    def test_hide_specific_stat(self, query_param):
         """
-        Test that the view render successfully when a query param is included
+        Test that the view renders successfully when a query param is included
 
         Expected behavior:
             - Status code 200.
             - template name is as expected.
             - tenant-stats div exist
-            - the query param is 'false'
+            - the query param is 'true'
             - CSS was included
             - JS was included
         """
-        url_endpoint = f"{reverse('stats-frontend:tenant')}?{query_param}=false"
+        url_endpoint = f"{reverse('stats-frontend:tenant')}?{query_param}=true"
 
         response = self.client.get(url_endpoint)
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(self.template_name, response.templates[0].name)
         self.assertContains(response, '<div id="tenant-stats"></div')
-        self.assertEqual("false", response.context[query_param])
+        self.assertEqual("true", response.context[query_param])
         self.assertContains(response, "tenant_stats/css/tenant_stats.css")
         self.assertContains(response, "tenant_stats/js/tenant_stats.js")

--- a/eox_nelp/stats/views.py
+++ b/eox_nelp/stats/views.py
@@ -21,19 +21,19 @@ def get_tenant_stats(request):
         /eox-nelp/stats/tenant/?videos=false&courses=false
 
     The available options are:
-        videos
-        courses
-        learners
-        instructors
-        problems
+        hideVideos
+        hideCourses
+        hideLearners
+        hideInstructors
+        hideProblems
     """
 
     context = {
-        "courses": "true",
-        "videos": "true",
-        "problems": "true",
-        "learners": "true",
-        "instructors": "true",
+        "hideCourses": "false",
+        "hideVideos": "false",
+        "hideProblems": "false",
+        "hideLearners": "false",
+        "hideInstructors": "false",
     }
     context.update(request.GET.dict())
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This implements explicit stats' query params since the current options are ambiguous  

## Testing instructions
1. check this branch
2.  test new queryparams, example `/eox-nelp/frontend/stats/tenant/?hideVideos=true&hideCourses&hideLearners=false`


### Result
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/47d81d63-4883-4659-a7ae-4aff1f1e9630)



