### PR TITLE
Jlc/experience relationships attributes

### DIFF
--- a/eox_nelp/course_experience/api/v1/serializers.py
+++ b/eox_nelp/course_experience/api/v1/serializers.py
@@ -1,4 +1,6 @@
 """Serializers used for the experience views."""
+from copy import copy
+
 from django.contrib.auth import get_user_model
 from rest_framework_json_api import serializers
 
@@ -13,6 +15,79 @@ from eox_nelp.course_experience.models import (
 from eox_nelp.edxapp_wrapper.course_overviews import CourseOverview
 
 User = get_user_model()
+COURSE_OVERVIEW_EXTRA_FIELD_MAPPING = {"display_name": "display_name"}
+USER_EXTRA_FIELD_MAPPING = {
+    "first_name": "first_name",
+    "last_name": "last_name",
+    "profile_name": "profile__name",
+    "username": "username",
+}
+
+
+def get_course_extra_attributes(value=None):
+    """Function to retrieve CourseOverview extra fields
+
+    Args:
+        value (CourseOverview instance): CourseOverview that the relation analize. Defaults to None.
+
+    Returns:
+        dict: dict object too add course extra fields
+    """
+    return {
+        "attributes": map_attributes_from_instance_to_dict(value, COURSE_OVERVIEW_EXTRA_FIELD_MAPPING)
+    }
+
+
+def get_user_extra_attributes(value=None):
+    """Function to retrieve User extra fields
+
+    Args:
+        value (Userinstance): User that the relation analize. Defaults to None.
+
+    Returns:
+        dict: dict object too add user extra fields
+    """
+    return {
+        "attributes": map_attributes_from_instance_to_dict(value, USER_EXTRA_FIELD_MAPPING)
+    }
+
+
+def map_attributes_from_instance_to_dict(instance, attributes_mapping):
+    """Create a dictionary that represents some fields or attributes of a instance based on
+    a attributes_mapping dictionary. This dict would have key, values which the key represent the
+    attribute to look in the instance and the value the key name in the output dict.
+    Based in the `attributes_mapping` you should use a dict with the following config:
+    {
+        "key_name": "field_name"
+    }
+    This would check in the instace instance.field_name and the value send it to output dict
+    like {"key_name": instance.field_name}
+    Also its is possible to check nested fields if you declarate the field of instance separated by `__`
+    eg:
+    {
+        "key_name": "field_level1__field_level2"
+    }
+    This example would check in the instace like instance.field_level1.field_level2 and in the output
+    dict like {"key_name": instance.field_level1.field_level2}
+    Args:
+        instance (instance class): Model or instance of class to retrieved fields.
+        attributes_mapping (dict): Dictionary map that has the fields to search and the keys name to output,
+
+    Returns:
+        instance_dict: dict representing the instance
+    """
+    instance_dict = {}
+    for extra_field, instance_field in attributes_mapping.items():
+        extra_value = None
+        instance_level = copy(instance)
+        for instance_field in instance_field.split("__"):
+            if hasattr(instance_level, instance_field):
+                instance_level = getattr(instance_level, instance_field)
+                extra_value = instance_level
+
+        instance_dict[extra_field] = extra_value
+
+    return instance_dict
 
 
 class ExperienceSerializer(serializers.ModelSerializer):
@@ -27,9 +102,11 @@ class ExperienceSerializer(serializers.ModelSerializer):
     )
     course_id = ExperienceResourceRelatedField(
         queryset=CourseOverview.objects,
+        get_extra_fields=get_course_extra_attributes,
     )
     author = ExperienceResourceRelatedField(
         queryset=User.objects,
+        get_extra_fields=get_user_extra_attributes,
     )
 
 

--- a/eox_nelp/course_experience/api/v1/tests/test_views.py
+++ b/eox_nelp/course_experience/api/v1/tests/test_views.py
@@ -61,20 +61,7 @@ class LikeDislikeUnitExperienceTestCase(UnitExperienceTestMixin, APITestCase):
                     "status": self.my_unit_like.status,
                     "item_id": f"{self.my_unit_like.item_id}",
                 },
-                "relationships": {
-                    "author": {
-                        "data": {
-                            "type": "User",
-                            "id": f"{self.user.id}",
-                        }
-                    },
-                    "course_id": {
-                        "data": {
-                            "type": "CourseOverview",
-                            "id": f"{self.my_course.id}",
-                        }
-                    }
-                }
+                "relationships": self.make_relationships_data()
             }
         }
         self.object_url_kwarg = {self.object_key: BASE_ITEM_ID}
@@ -117,20 +104,7 @@ class ReportUnitExperienceTestCase(UnitExperienceTestMixin, APITestCase):
                     "reason": f"{self.my_unit_report.reason}",
                     "item_id": f"{self.my_unit_report.item_id}",
                 },
-                "relationships": {
-                    "author": {
-                        "data": {
-                            "type": "User",
-                            "id": f"{self.user.id}",
-                        }
-                    },
-                    "course_id": {
-                        "data": {
-                            "type": "CourseOverview",
-                            "id": f"{self.my_course.id}",
-                        }
-                    }
-                }
+                "relationships": self.make_relationships_data()
             }
         }
         self.object_url_kwarg = {self.object_key: BASE_ITEM_ID}
@@ -190,20 +164,7 @@ class LikeDislikeCourseExperienceTestCase(CourseExperienceTestMixin, APITestCase
                     "username": f"{self.user.username}",
                     "status": self.my_course_like.status,
                 },
-                "relationships": {
-                    "author": {
-                        "data": {
-                            "type": "User",
-                            "id": f"{self.user.id}",
-                        }
-                    },
-                    "course_id": {
-                        "data": {
-                            "type": "CourseOverview",
-                            "id": f"{self.my_course.id}",
-                        }
-                    }
-                }
+                "relationships": self.make_relationships_data()
             }
         }
 
@@ -244,20 +205,7 @@ class ReportCourseExperienceTestCase(CourseExperienceTestMixin, APITestCase):
                     "username": f"{self.user.username}",
                     "reason": f"{self.my_course_report.reason}"
                 },
-                "relationships": {
-                    "author": {
-                        "data": {
-                            "type": "User",
-                            "id": f"{self.user.id}"
-                        }
-                    },
-                    "course_id": {
-                        "data": {
-                            "type": "CourseOverview",
-                            "id": f"{self.my_course.id}"
-                        }
-                    }
-                }
+                "relationships": self.make_relationships_data()
             }
         }
 
@@ -315,20 +263,7 @@ class FeedbackCourseExperienceTestCase(CourseExperienceTestMixin, APITestCase):
                     "public": self.my_course_feedback.public,
                     "recommended": self.my_course_feedback.recommended,
                 },
-                "relationships": {
-                    "author": {
-                        "data": {
-                            "type": "User",
-                            "id": f"{self.user.id}"
-                        }
-                    },
-                    "course_id": {
-                        "data": {
-                            "type": "CourseOverview",
-                            "id": f"{self.my_course.id}"
-                        }
-                    }
-                }
+                "relationships": self.make_relationships_data()
             }
         }
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This change is applied to course-experience api.
The relations file inherits from json api relation but add some extra fields
in the attributes of the relationship model.
The base json api only adds id and type, with this change you can add extra model
attributes.
https://github.com/django-json-api/django-rest-framework-json-api/blob/main/rest_framework_json_api/relations.py#L255

The attributes field was selected due to the recommendation of jsonapi.
https://jsonapi.org/format/#document-resource-objects

## Testing instructions
Clone this repo and look al the course experience API endpoints.
Know they have extra data to each relationship.
``` json
{
    "like/units": "/eox-nelp/api/experience/v1/like/units/",
    "report/units": "/eox-nelp/api/experience/v1/report/units/",
    "like/courses": "/eox-nelp/api/experience/v1/like/courses/",
    "report/courses": "/eox-nelp/api/experience/v1/report/courses/",
    "feedback/courses": "/eox-nelp/api/experience/v1/feedback/courses/",
    "feedback/public/courses": "/eox-nelp/api/experience/v1/feedback/public/courses/"
}
```
### Before
No extra field data to the relationships. Only id and type.
![Peek 2023-07-06 15-57](https://github.com/eduNEXT/eox-nelp/assets/51926076/dcbf1b93-0f2e-4583-b780-26f0c3978333)

### After
Configurable attributes field with model relation fields.
![Peek 2023-07-06 15-58](https://github.com/eduNEXT/eox-nelp/assets/51926076/ac170b1f-cb31-46d4-9041-3347337adf84)


## Additional information

**jira story**:
https://edunext.atlassian.net/jira/software/c/projects/FUTUREX/boards/36?modal=detail&selectedIssue=FUTUREX-459

## next steps
Remove `username` for the main attributes field of each experience APIview  because with this change the relationship of the author already has it.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
