### PR TITLE
feat: add extra fields options to relationships

### DIFF
--- a/eox_nelp/course_experience/api/v1/relations.py
+++ b/eox_nelp/course_experience/api/v1/relations.py
@@ -1,0 +1,40 @@
+"""Relations used for customize experience views. The relations are used to specify how to manage
+the relations fields in the serializers.
+https://github.com/encode/django-rest-framework/blob/master/rest_framework/relations.py
+"""
+from rest_framework_json_api.relations import ResourceRelatedField
+
+
+class ExperienceResourceRelatedField(ResourceRelatedField):
+    """Class to configure relations for course experience API.
+
+    Ancestors:
+        relation (ResourceRelatedField): the ResourceRelatedField relation from json api
+
+    """
+    def __init__(self, **kwargs):
+        """ Include an additional kwargs parameter to manage the extra model fields to be shown.
+        The value of the kwarg should be  a function with kwargs accepting value: (value=instance).
+        get_extra_fields (function)
+        """
+        self.get_extra_fields = kwargs.pop('get_extra_fields', None)
+        super().__init__(**kwargs)
+
+    def to_representation(self, value):
+        """Add to the base json api representation extra fields apart from `id` and `type`
+        using a function passed via `self.get_extra_fields`
+        https://github.com/django-json-api/django-rest-framework-json-api/blob/main/rest_framework_json_api/relations.py#L255
+        The attributes shape is based on
+        https://jsonapi.org/format/#document-resource-objects
+        Args:
+            value (instance model): instance of foreign model extracted from relation
+
+        Returns:
+           json_api_representation (ordered-dict): json api representation with extra model data in attributes field.
+        """
+        json_api_representation = super().to_representation(value)
+
+        if self.get_extra_fields and callable(self.get_extra_fields):
+            json_api_representation.update(self.get_extra_fields(value=value))
+
+        return json_api_representation

--- a/eox_nelp/course_experience/api/v1/serializers.py
+++ b/eox_nelp/course_experience/api/v1/serializers.py
@@ -1,6 +1,8 @@
 """Serializers used for the experience views."""
+from django.contrib.auth import get_user_model
 from rest_framework_json_api import serializers
 
+from eox_nelp.course_experience.api.v1.relations import ExperienceResourceRelatedField
 from eox_nelp.course_experience.models import (
     FeedbackCourse,
     LikeDislikeCourse,
@@ -8,6 +10,9 @@ from eox_nelp.course_experience.models import (
     ReportCourse,
     ReportUnit,
 )
+from eox_nelp.edxapp_wrapper.course_overviews import CourseOverview
+
+User = get_user_model()
 
 
 class ExperienceSerializer(serializers.ModelSerializer):
@@ -19,6 +24,12 @@ class ExperienceSerializer(serializers.ModelSerializer):
     """
     username = serializers.CharField(
         source="author.username", required=False, allow_blank=True
+    )
+    course_id = ExperienceResourceRelatedField(
+        queryset=CourseOverview.objects,
+    )
+    author = ExperienceResourceRelatedField(
+        queryset=User.objects,
     )
 
 


### PR DESCRIPTION

<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This change is applied to course-experience api.
The relations file inherit from json api relation but add the possibility to add some extra fields using a function. The function has to be passed through the new relation using `get_extra_fields` kwarg. There you can calculate a dict that would be added to corresponding relationhips field. The base json api only add `id` and `type`, with this change you cad add extra model attributes.
https://github.com/django-json-api/django-rest-framework-json-api/blob/main/rest_framework_json_api/relations.py#L255

## Testing instructions
Clone the repo and check anything is broken and the feedback API work with it same functionality.
### After
![image](https://github.com/eduNEXT/eox-nelp/assets/51926076/05ea70fe-75fe-4b63-a259-06be78bc67a2)

## Additional information

**jira story**:
https://edunext.atlassian.net/jira/software/c/projects/FUTUREX/boards/36?modal=detail&selectedIssue=FUTUREX-459

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
