### PR TITLE
feat: add setting configuration for relationships

### DIFF
--- a/eox_nelp/course_experience/api/v1/serializers.py
+++ b/eox_nelp/course_experience/api/v1/serializers.py
@@ -1,4 +1,5 @@
 """Serializers used for the experience views."""
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework_json_api import serializers
 
@@ -32,9 +33,13 @@ def get_course_extra_attributes(value=None):
     Returns:
         dict: dict object too add course extra fields
     """
-    return {
-        "attributes": map_instance_attributes_to_dict(value, COURSE_OVERVIEW_EXTRA_FIELD_MAPPING)
-    }
+    course_overview_mapping = getattr(
+        settings,
+        "COURSE_EXPERIENCE_SETTINGS",
+        {},
+    ).get("COURSE_OVERVIEW_EXTRA_FIELD_MAPPING", COURSE_OVERVIEW_EXTRA_FIELD_MAPPING)
+
+    return {"attributes": map_instance_attributes_to_dict(value, course_overview_mapping)}
 
 
 def get_user_extra_attributes(value=None):
@@ -46,9 +51,13 @@ def get_user_extra_attributes(value=None):
     Returns:
         dict: dict object too add user extra fields
     """
-    return {
-        "attributes": map_instance_attributes_to_dict(value, USER_EXTRA_FIELD_MAPPING)
-    }
+    user_mapping = getattr(
+        settings,
+        "COURSE_EXPERIENCE_SETTINGS",
+        {},
+    ).get("USER_EXTRA_FIELD_MAPPING", USER_EXTRA_FIELD_MAPPING)
+
+    return {"attributes": map_instance_attributes_to_dict(value, user_mapping)}
 
 
 class ExperienceSerializer(serializers.ModelSerializer):


### PR DESCRIPTION

<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description
This add the possibility to configure the course_overview mapping and user mapping via django settings using
`COURSE_EXPERIENCE_SETTINGS`
Know you can configure the relationship extra field via settings in tenant config.
``` json
"COURSE_EXPERIENCE_SETTINGS": {
    "COURSE_OVERVIEW_EXTRA_FIELD_MAPPING": {
        "ultra_name": "courseultra",
        "course_key": "instance__field"
    },
    "USER_EXTRA_FIELD_MAPPING": {
        "mega_name": "userultra",
        "user_key": "user__field"
    }
}
```


## Testing instructions
Clone repo and add variable keys to configure course_experience_keys for relationship in tenant config as above.


### After
![Peek 2023-07-10 18-32](https://github.com/eduNEXT/eox-nelp/assets/51926076/60596f69-3543-4c64-88df-1360c0b5107f)

## Additional information
**related jira story**:
https://edunext.atlassian.net/jira/software/c/projects/FUTUREX/boards/36?modal=detail&selectedIssue=FUTUREX-459


## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
