### PR TITLE
feat: add prefix to reference_id parameter in certificate api client

### DIFF
--- a/eox_nelp/api_clients/certificates.py
+++ b/eox_nelp/api_clients/certificates.py
@@ -49,7 +49,7 @@ class ExternalCertificatesApiClient(AbstractBasicAuthApiClient):
         path = "Certificates"
         user = certificate_data["user"]
         payload = {
-            "reference_id": certificate_data["id"],
+            "reference_id": f"nelc-openedx-lms-cert-{certificate_data['id']}",
             "date": {
                 "issuance": certificate_data["created_at"],
                 "expiration": None,


### PR DESCRIPTION
## Description

This adds a prefix to the payload reference id parameter, I didn't include the host since I consider that information is not relevant because the certificate is not associated with a tenant, that is associated with a course and a course could be associated with multiple tenants 
