### PR TITLE
feat: add new admin action that allows to create external certificates

### DIFF
--- a/eox_nelp/admin/__init__.py
+++ b/eox_nelp/admin/__init__.py
@@ -1,6 +1,7 @@
 """General admin module file.
 Register all the nelp admin models.
 """
+from eox_nelp.admin.certificates import *  # noqa: F401
 from eox_nelp.admin.course_creators import *  # noqa: F401
 from eox_nelp.course_experience.admin import *  # noqa: F401
 from eox_nelp.notifications.admin import *  # noqa: F401

--- a/eox_nelp/admin/certificates.py
+++ b/eox_nelp/admin/certificates.py
@@ -1,0 +1,73 @@
+"""Certificates admin file.
+Contains all the nelp admin models for certificates.
+
+Classes:
+    NelpGeneratedCertificateAdmin: EoxNelp Certificates admin class.
+
+Functions:
+    create_external_certificate_action: Allow to create external certificates.
+"""
+from django.contrib import admin
+from django.utils import timezone
+from eox_core.edxapp_wrapper.certificates import get_generated_certificate
+from openedx_events.learning.data import CertificateData, CourseData, UserData, UserPersonalData
+
+from eox_nelp.admin.register_admin_model import register_admin_model as register
+from eox_nelp.edxapp_wrapper.certificates import GeneratedCertificateAdmin
+from eox_nelp.signals.tasks import create_external_certificate
+from eox_nelp.signals.utils import _generate_external_certificate_data
+
+GeneratedCertificate = get_generated_certificate()
+
+
+@admin.action(description="Create external certificates")
+def create_external_certificate_action(modeladmin, request, queryset):  # pylint: disable=unused-argument
+    """
+    This creates CertificateData and runs the create_external_certificate task for every record
+    in the queryset, to allow to create certificates in the external NELP service.
+
+    Args:
+        modeladmin: Instance of NelpGeneratedCertificateAdmin
+        request: Current django request.
+        queryset: Selected records.
+    """
+
+    for certificate in queryset:
+        certificate_data = CertificateData(
+            user=UserData(
+                pii=UserPersonalData(
+                    username=certificate.user.username,
+                    email=certificate.user.email,
+                    name=certificate.user.profile.name,
+                ),
+                id=certificate.user.id,
+                is_active=certificate.user.is_active,
+            ),
+            course=CourseData(
+                course_key=certificate.course_id,
+            ),
+            mode=certificate.mode,
+            grade=certificate.grade,
+            current_status=certificate.status,
+            download_url=certificate.download_url,
+            name=certificate.name,
+        )
+        time = certificate.modified_date.astimezone(timezone.utc)
+
+        create_external_certificate.delay(
+            external_certificate_data=_generate_external_certificate_data(
+                time=time,
+                certificate_data=certificate_data,
+            )
+        )
+
+
+class NelpGeneratedCertificateAdmin(GeneratedCertificateAdmin):
+    """
+    Nelp GeneratedCertificate admin class, this adds the NELP admin custom
+    behavior, for the GeneratedCertificate model.
+    """
+    actions = [create_external_certificate_action]
+
+
+register(GeneratedCertificate, NelpGeneratedCertificateAdmin)

--- a/eox_nelp/edxapp_wrapper/backends/certificates_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/certificates_m_v1.py
@@ -1,0 +1,15 @@
+"""Backend for certificates module.
+This file contains all the necessary certificates dependencies from
+https://github.com/eduNEXT/edunext-platform/tree/master/lms/djangoapps/certificates
+"""
+from lms.djangoapps.certificates import admin  # pylint: disable=import-error
+
+
+def get_generated_certificates_admin():
+    """Allow to get the openedX GeneratedCertificateAdmin class.
+    https://github.com/eduNEXT/edunext-platform/tree/master/lms/djangoapps/certificates/admin.py
+
+    Returns:
+        GeneratedCertificateAdmin class.
+    """
+    return admin.GeneratedCertificateAdmin

--- a/eox_nelp/edxapp_wrapper/certificates.py
+++ b/eox_nelp/edxapp_wrapper/certificates.py
@@ -1,0 +1,14 @@
+"""Wrapper certificates module file.
+This contains all the required dependencies from certificates.
+
+Attributes:
+    backend:Imported module by using the plugin settings.
+    GeneratedCertificateAdmin: Wrapper GeneratedCertificateAdmin class.
+"""
+from importlib import import_module
+
+from django.conf import settings
+
+backend = import_module(settings.EOX_NELP_CERTIFICATES_BACKEND)
+
+GeneratedCertificateAdmin = backend.get_generated_certificates_admin()

--- a/eox_nelp/edxapp_wrapper/test_backends/certificates_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/certificates_m_v1.py
@@ -1,0 +1,10 @@
+"""Test backend for certificates module."""
+from mock import Mock
+
+
+def get_generated_certificates_admin():
+    """Return test admin class.
+    Returns:
+        Mock class.
+    """
+    return Mock()

--- a/eox_nelp/settings/common.py
+++ b/eox_nelp/settings/common.py
@@ -44,6 +44,7 @@ def plugin_settings(settings):
     settings.EOX_NELP_STUDENT_BACKEND = 'eox_nelp.edxapp_wrapper.backends.student_m_v1'
     settings.EOX_NELP_EDXMAKO_BACKEND = 'eox_nelp.edxapp_wrapper.backends.edxmako_m_v1'
     settings.EOX_NELP_BRANDING_BACKEND = 'eox_nelp.edxapp_wrapper.backends.branding_m_v1'
+    settings.EOX_NELP_CERTIFICATES_BACKEND = 'eox_nelp.edxapp_wrapper.backends.certificates_m_v1'
 
     settings.FUTUREX_API_URL = 'https://testing-site.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -31,6 +31,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.EOX_NELP_STUDENT_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.student_m_v1'
     settings.EOX_NELP_EDXMAKO_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.edxmako_m_v1'
     settings.EOX_NELP_BRANDING_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.branding_m_v1'
+    settings.EOX_NELP_CERTIFICATES_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.certificates_m_v1'
 
     settings.FUTUREX_API_URL = 'https://testing.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description
Adds a new admin action class that allows to create external certificates, this logic came from the model implementation https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/certificates/models.py#L524 and the previous implemented celery task  https://github.com/eduNEXT/eox-nelp/blob/master/eox_nelp/signals/tasks.py#L140

Issue:
https://edunext.atlassian.net/browse/FUTUREX-486
