### PR TITLE
fix: limit registration based on current installed apps

### DIFF
--- a/eox_nelp/admin/register_admin_model.py
+++ b/eox_nelp/admin/register_admin_model.py
@@ -2,6 +2,7 @@
 methods:
     register_admin_model: Force register admin model.
 """
+from django.apps import apps
 from django.contrib import admin
 
 
@@ -11,6 +12,11 @@ def register_admin_model(model, admin_model):
         model: Django model.
         admin_class: Admin model.
     """
+    try:
+        apps.get_app_config(model._meta.app_label)  # pylint: disable=protected-access
+    except LookupError:
+        return
+
     if admin.site.is_registered(model):
         admin.site.unregister(model)
 

--- a/eox_nelp/edxapp_wrapper/backends/certificates_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/certificates_m_v1.py
@@ -2,7 +2,9 @@
 This file contains all the necessary certificates dependencies from
 https://github.com/eduNEXT/edunext-platform/tree/master/lms/djangoapps/certificates
 """
-from lms.djangoapps.certificates import admin  # pylint: disable=import-error
+from django.apps import apps
+from django.contrib import admin
+from lms.djangoapps import certificates  # pylint: disable=import-error
 
 
 def get_generated_certificates_admin():
@@ -12,4 +14,7 @@ def get_generated_certificates_admin():
     Returns:
         GeneratedCertificateAdmin class.
     """
-    return admin.GeneratedCertificateAdmin
+    if apps.is_installed(certificates.models.__package__):
+        return certificates.admin.GeneratedCertificateAdmin
+
+    return admin.ModelAdmin


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This fixes two things

1. This won't allow to register an admin model if the django app is not installed [eox_nelp/admin/register_admin_model.py](https://github.com/eduNEXT/eox-nelp/compare/and/fix_studio_admin?expand=1#diff-fe7f87f2f8d29360092bdc8483652a8371be8b968330d8f275c994001550237e)
2.  when the import` from lms.djangoapps.certificates import admin` is made in that way all registration processes inside that file are performed, so the import way is changed in order to avoid undesired registrations and before importing the admin model a django app validation is executed [eox_nelp/edxapp_wrapper/backends/certificates_m_v1.py](https://github.com/eduNEXT/eox-nelp/compare/and/fix_studio_admin?expand=1#diff-2ca90a23b1422824233f120b2e1fd242bfae3bcb81fd784d2c827867ee18844f)

## Testing instructions

1. check this branch
2. go to the studio admin view 


