### PR TITLE
feat: adding enrollment receiver

### DIFF
--- a/eox_nelp/apps.py
+++ b/eox_nelp/apps.py
@@ -51,6 +51,12 @@ class EoxNelpConfig(AppConfig):
                         'signal_path': 'openedx_events.learning.signals.CERTIFICATE_CREATED',
                         'dispatch_uid': 'certificate_publisher_receiver',
                     },
+                    {
+                        'receiver_func_name': 'enrollment_publisher',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'dispatch_uid': 'enrollment_publisher_receiver',
+                        'sender_path': 'common.djangoapps.student.models.CourseEnrollment',
+                    },
                 ],
             },
         },

--- a/eox_nelp/edxapp_wrapper/test_backends/grades_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/grades_m_v1.py
@@ -8,4 +8,4 @@ def get_course_grade_factory():
     Returns:
         Mock class.
     """
-    return Mock
+    return Mock()

--- a/eox_nelp/signals/utils.py
+++ b/eox_nelp/signals/utils.py
@@ -6,14 +6,12 @@ Functions:
 """
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from eox_core.edxapp_wrapper.certificates import get_generated_certificate
 from eox_core.edxapp_wrapper.grades import get_course_grade_factory
 from opaque_keys.edx.keys import CourseKey
 
 from eox_nelp.utils import is_valid_national_id
 
 CourseGradeFactory = get_course_grade_factory()
-GeneratedCertificate = get_generated_certificate()
 User = get_user_model()
 
 
@@ -34,17 +32,12 @@ def _generate_external_certificate_data(time, certificate_data):
         Dict: certificate data
     """
     user = User.objects.get(id=certificate_data.user.id)
-    certificate = GeneratedCertificate.objects.get(
-        user=user,
-        course_id=certificate_data.course.course_key,
-    )
     group_codes = getattr(settings, "EXTERNAL_CERTIFICATES_GROUP_CODES", {})
     course_id = str(certificate_data.course.course_key)
     extra_info = getattr(user, "extrainfo", None)
     national_id = user.username[:10]  # saml association extra filter
 
     return {
-        "id": certificate.id,
         "reference_id": generate_reference_id(national_id, course_id),
         "created_at": str(time.date()),
         "expiration_date": None,


### PR DESCRIPTION


<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This will create external certificates when a user enrolls in a course, generally that certificate will have a grade of 0 and then that will be updated by the certificate_publisher

https://edunext.atlassian.net/browse/FUTUREX-488

## Testing instructions

1. Set ENABLE_CERTIFICATE_PUBLISHER to True
2. Save a course enrollment in the admin panel, then check logs. Change the course enrollment mode to get different logs

