### PR TITLE
feat: add custom social_details pipeline

### DIFF
--- a/eox_nelp/auth_pipeline.py
+++ b/eox_nelp/auth_pipeline.py
@@ -1,0 +1,30 @@
+"""Custom NELP  authentication pipelines
+
+functions:
+    social_details: Allows to map response fields to user standar fields.
+"""
+from django.conf import settings
+from social_core.pipeline.social_auth import social_details as social_core_details
+
+
+def social_details(backend, details, response, *args, **kwargs):
+    """This is an extension of `social_core.pipeline.social_auth.social_details` that allows
+    to map response fields in standard user fields. This depends on the SOCIAL_DETAILS_MAPPING
+    setting that should be configured as the following:
+
+    Example:
+
+        SOCIAL_DETAILS_MAPPING = {
+            "username": "custom_username_response_value",
+            "email": "custom_email_response_value",
+            "first_name": "custom_first_name_response_value",
+            "last_name": "custom_last_name_response_value",
+            "fullname": "custom_fullname_response_value"
+        }
+    """
+    details = social_core_details(backend, details, response, *args, **kwargs)
+
+    for key, value in getattr(settings, "SOCIAL_DETAILS_MAPPING", {}).items():
+        details["details"][key] = response.get(value)
+
+    return details


### PR DESCRIPTION


<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This is an extension of `social_core.pipeline.social_auth.social_details` that allows to map response fields in standard user fields.

Part of https://edunext.atlassian.net/browse/FUTUREX-515

## Testing instructions

I tested this by adding the file to the debug server on production 
This change was required 
`AUTHENTICATION_BACKENDS.insert(0, "eox_core.social_tpa_backends.ConfigurableOpenIdConnectAuth")`

## Result 
![sso-mt](https://github.com/eduNEXT/eox-nelp/assets/36200299/bb07d88d-b8cc-4f94-bd7b-f3f814f6b011)

