### PR TITLE
feat: add XApiBaseEnrollmentFilter

### DIFF
--- a/eox_nelp/edxapp_wrapper/backends/course_overviews_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/course_overviews_m_v1.py
@@ -3,6 +3,7 @@
 This file contains all the necessary dependencies from
 https://github.com/eduNEXT/edunext-platform/tree/master/openedx/core/djangoapps/content/course_overviews
 """
+from openedx.core.djangoapps.content.course_overviews.api import get_course_overviews  # pylint: disable=import-error
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # pylint: disable=import-error
 
 
@@ -14,3 +15,13 @@ def get_course_overview_model():
         CourseOverview model.
     """
     return CourseOverview
+
+
+def get_course_overviews_method():
+    """Allow to get get_course_overviews method from
+    https://github.com/eduNEXT/edunext-platform/blob/master/openedx/core/djangoapps/content/course_overviews/api.py
+
+    Returns:
+        get_course_overviews method.
+    """
+    return get_course_overviews

--- a/eox_nelp/edxapp_wrapper/course_overviews.py
+++ b/eox_nelp/edxapp_wrapper/course_overviews.py
@@ -4,6 +4,7 @@ This contains all the required dependencies from course_overviews.
 Attributes:
     backend:Imported module by using the plugin settings.
     CourseOverview: Wrapper CourseOverview model.
+    get_course_overviews: Wrapper of et_course_overviews method.
 """
 from importlib import import_module
 
@@ -12,3 +13,4 @@ from django.conf import settings
 backend = import_module(settings.EOX_NELP_COURSE_OVERVIEWS_BACKEND)
 
 CourseOverview = backend.get_course_overview_model()
+get_course_overviews = backend.get_course_overviews_method()

--- a/eox_nelp/edxapp_wrapper/test_backends/course_overviews_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/course_overviews_m_v1.py
@@ -1,5 +1,6 @@
 """Test backend for course overviews module."""
 from django.db import models
+from mock import Mock
 from opaque_keys.edx.django.models import CourseKeyField
 
 from eox_nelp.edxapp_wrapper.test_backends import create_test_model
@@ -19,3 +20,11 @@ def get_course_overview_model():
     return create_test_model(
         "CourseOverview", "eox_nelp", __package__, course_overview_fields
     )
+
+
+def get_course_overviews_method():
+    """Return test function.
+    Returns:
+        Mock class.
+    """
+    return Mock()

--- a/eox_nelp/openedx_filters/tests/xapi/tests_filters.py
+++ b/eox_nelp/openedx_filters/tests/xapi/tests_filters.py
@@ -2,12 +2,14 @@
 
 Classes:
     XApiActorFilterTestCase: Tests cases for XApiActorFilter filter class.
+    XApiBaseEnrollmentFilterTestCase: Test cases for XApiBaseEnrollmentFilter filter class.
 """
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-from tincan import Agent
+from mock import patch
+from tincan import Activity, ActivityDefinition, Agent, LanguageMap
 
-from eox_nelp.openedx_filters.xapi.filters import XApiActorFilter
+from eox_nelp.openedx_filters.xapi.filters import DEFAULT_LANGUAGE, XApiActorFilter, XApiBaseEnrollmentFilter
 
 User = get_user_model()
 
@@ -68,3 +70,88 @@ class XApiActorFilterTestCase(TestCase):
 
         self.assertEqual(f"mailto:{self.email}", actor.mbox)
         self.assertEqual(self.username, actor.name)
+
+
+class XApiBaseEnrollmentFilterTestCase(TestCase):
+    """Test class for XApiBaseEnrollmentFilter filter class."""
+
+    def setUp(self):
+        """Setup common conditions for every test case"""
+        self.filter = XApiBaseEnrollmentFilter(
+            filter_type="event_routing_backends.processors.xapi.enrollment_events.base_enrollment.get_object",
+            running_pipeline=["eox_nelp.openedx_filters.xapi.filters.XApiBaseEnrollmentFilter"],
+        )
+
+    def test_course_id_not_found(self):
+        """ Test case when the course_id cannot be extracted from the Activity id.
+
+        Expected behavior:
+            - Returned value is the same as the given value.
+        """
+        activity = Activity(
+            id="https://example.com/course/course-v1-invalid-edx+CS105+2023-T3",
+        )
+
+        returned_activity = self.filter.run_filter(result=activity)["result"]
+
+        self.assertEqual(activity, returned_activity)
+
+    @patch("eox_nelp.openedx_filters.xapi.filters.get_course_from_id")
+    def test_update_result(self, get_course_mock):
+        """ Test case when name and description are updated.
+
+        Expected behavior:
+            - Definition name has been updated.
+            - Definition description has been updated.
+            - get_course_from_id was called with the right parameter.
+        """
+        course = {
+            "display_name": "new-course-name",
+            "language": "ar",
+            "short_description": "This is a short description",
+        }
+
+        get_course_mock.return_value = course
+        activity = Activity(
+            id="https://example.com/course/course-v1:edx+CS105+2023-T3",
+            definition=ActivityDefinition(
+                type="testing",
+                name=LanguageMap(en="old-course-name"),
+            ),
+        )
+
+        returned_activity = self.filter.run_filter(result=activity)["result"]
+
+        self.assertEqual({course['language']: course["display_name"]}, returned_activity.definition.name)
+        self.assertEqual({course['language']: course["short_description"]}, returned_activity.definition.description)
+        get_course_mock.assert_called_once_with("course-v1:edx+CS105+2023-T3")
+
+    @patch("eox_nelp.openedx_filters.xapi.filters.get_course_from_id")
+    def test_invalid_language(self, get_course_mock):
+        """ Test case when language has not been set.
+
+        Expected behavior:
+            - Definition name has been updated with default language.
+            - Definition description has been updated with default language.
+            - get_course_from_id was called with the right parameter.
+        """
+        course = {
+            "display_name": "new-course-name",
+            "language": None,
+            "short_description": "This is a short description",
+        }
+
+        get_course_mock.return_value = course
+        activity = Activity(
+            id="https://example.com/course/course-v1:edx+CS105+2023-T3",
+            definition=ActivityDefinition(
+                type="testing",
+                name=LanguageMap(en="old-course-name"),
+            ),
+        )
+
+        returned_activity = self.filter.run_filter(result=activity)["result"]
+
+        self.assertEqual({DEFAULT_LANGUAGE: course["display_name"]}, returned_activity.definition.name)
+        self.assertEqual({DEFAULT_LANGUAGE: course["short_description"]}, returned_activity.definition.description)
+        get_course_mock.assert_called_once_with("course-v1:edx+CS105+2023-T3")

--- a/eox_nelp/tests/test_utils.py
+++ b/eox_nelp/tests/test_utils.py
@@ -1,0 +1,101 @@
+"""This file contains all the test for the utils.py file.
+
+Classes:
+    ExtractCourseIdFromStringTestCase: Tests cases for the extract_course_id_from_string method.
+    GetCourseFromIdTestCase: Tests cases for the get_course_from_id method.
+"""
+from ddt import data, ddt
+from django.test import TestCase
+from mock import patch
+from opaque_keys.edx.keys import CourseKey
+
+from eox_nelp.utils import extract_course_id_from_string, get_course_from_id
+
+
+@ddt
+class ExtractCourseIdFromStringTestCase(TestCase):
+    """Test class for the extract_course_id_from_string method."""
+
+    @data(
+        "this is a long string",
+        "hjsdgafhawsdbfhsdyafgbhjsdbf1784561553415534",
+        "this is a similar string course-v1:77777554a45sd4a2ad42s45d",
+        "https://example.com/course/course-v1edx+CS105+2023-T3"
+    )
+    def test_course_id_not_found(self, value):
+        """ Test that the method returns an empty string when any course_id is not found
+
+        Expected behavior:
+            - Returned value is an empty string
+        """
+        result = extract_course_id_from_string(value)
+
+        self.assertEqual("", result)
+
+    @data(
+        ["course-v1:edx+PS874+2023-T3", "this is a course-v1:edx+PS874+2023-T3/) long string"],
+        ["course-v1:edunext+CS105+2019-P3", "hjsdgafhawsdbfhgbhjsdbf1784561553415534course-v1:edunext+CS105+2019-P3"],
+        ["course-v1:NELC+TR675+2022-K3", "this course-v1:NELC+TR675+2022-K3/ is a similar string course-v1:77775s45d"],
+        ["course-v1:edx+CS105+2023-T3", "https://example.com/course/course-v1:edx+CS105+2023-T3"],
+    )
+    def test_course_id_found(self, value):
+        """ Test that the method returns right course id.
+
+        Expected behavior:
+            - Returned value is the expected course id.
+        """
+        result = extract_course_id_from_string(value[1])
+
+        self.assertEqual(value[0], result)
+
+    def test_multiple_valid_ids(self):
+        """ Test that the method returns the first value that matches the regular expression.
+
+        Expected behavior:
+            - Returned value is the expected course id.
+        """
+        string = (
+            "/course-v1:edx+CS105+2023-T3/"
+            "/course-v1:NELC+TR675+2022-K3/"
+            "/course-v1:edx+PS874+2023-T3/"
+            "/course-v1:edunext+CS105+2019-P3/"
+        )
+
+        result = extract_course_id_from_string(string)
+
+        self.assertEqual("course-v1:edx+CS105+2023-T3", result)
+
+
+class GetCourseFromIdTestCase(TestCase):
+    """Test class for the get_course_from_id method."""
+
+    @patch("eox_nelp.utils.get_course_overviews")
+    def test_course_id_not_found(self, course_overviews_mock):
+        """ Test that the method raises the right exception when there are no courses.
+
+        Expected behavior:
+            - Raises ValueError exception.
+            - get_course_overviews method was called with the right parameter.
+        """
+        course_id = "course-v1:edx+CS105+2023-T3"
+        course_overviews_mock.return_value = []
+
+        self.assertRaises(ValueError, get_course_from_id, course_id)
+        course_overviews_mock.assert_called_once_with([CourseKey.from_string(course_id)])
+
+    @patch("eox_nelp.utils.get_course_overviews")
+    def test_course_id_found(self, course_overviews_mock):
+        """ Test that the method returns the expected value.
+
+        Expected behavior:
+            - Returned value is the expected course.
+            - get_course_overviews method was called with the right parameter.
+        """
+        course_id = "course-v1:edx+CS105+2023-T3"
+        expected_course = {"name": "test-course", "short_description": "This is a great course"}
+        course_overviews_mock.return_value = [expected_course]
+
+        course = get_course_from_id(course_id)
+
+        self.assertEqual(expected_course, course)
+        course_overviews_mock.assert_called_once_with([CourseKey.from_string(course_id)])

--- a/eox_nelp/utils.py
+++ b/eox_nelp/utils.py
@@ -2,7 +2,12 @@
 import re
 from copy import copy
 
+from opaque_keys.edx.keys import CourseKey
+
+from eox_nelp.edxapp_wrapper.course_overviews import get_course_overviews
+
 NATIONAL_ID_REGEX = r"^[1-2]\d{9}$"
+COURSE_ID_REGEX = r'(course-v1:[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
 
 
 def map_instance_attributes_to_dict(instance, attributes_mapping):
@@ -78,3 +83,39 @@ def is_valid_national_id(national_id, raise_exception=False):
         )
 
     return check_national_id
+
+
+def extract_course_id_from_string(string):
+    """This return a sub-string that matches the course_ir regex
+
+    Arguments:
+        string: This is a string that could contains a sub-string that matches with the course_id form.
+
+    Returns:
+        course_id <string>: Returns course id or an empty string.
+    """
+    matches = re.search(COURSE_ID_REGEX, string)
+
+    if matches:
+        return matches.group()
+
+    return ""
+
+
+def get_course_from_id(course_id):
+    """
+    Get Course object using the `course_id`.
+
+    Arguments:
+        course_id (str) :   ID of the course
+
+    Returns:
+        Course
+    """
+    course_key = CourseKey.from_string(course_id)
+    course_overviews = get_course_overviews([course_key])
+
+    if course_overviews:
+        return course_overviews[0]
+
+    raise ValueError(f"Course with id {course_id} does not exist.")


### PR DESCRIPTION


<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This filter allows to implement the required object structure by the NELC team https://edunext.atlassian.net/browse/FUTUREX-251

## Testing instructions

1. Use this version of event routing https://github.com/nelc/event-routing-backends/pull/5
2. add the settings        
```
        OPEN_EDX_FILTERS_CONFIG = {
            "event_routing_backends.processors.xapi.enrollment_events.base_enrollment.get_object": {
                "pipeline": ["eox_nelp.openedx_filters.xapi.filters.XApiBaseEnrollmentFilter"],
                "fail_silently": False,
            },
        }
```
3. This uses the language and the short_description studio fields, set them
4. Perform an enrollment or unenrollment event
5.  Check the result, in my case I'm using aspects, so I can check that in the superset panel

### Before
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/eeb3e25d-1299-4656-a173-c44d1e713914)


### After
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/bf83c76f-2b79-453f-8f31-bae858b46f80)


## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
