### PR TITLE
And/add base problem filter

### DIFF
--- a/eox_nelp/openedx_filters/tests/xapi/tests_filters.py
+++ b/eox_nelp/openedx_filters/tests/xapi/tests_filters.py
@@ -3,13 +3,21 @@
 Classes:
     XApiActorFilterTestCase: Tests cases for XApiActorFilter filter class.
     XApiBaseEnrollmentFilterTestCase: Test cases for XApiBaseEnrollmentFilter filter class.
+    XApiBaseProblemsFilterTestCase: Test cases for XXApiBaseProblemsFilter filter class.
 """
+from ddt import data, ddt
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from mock import Mock, patch
 from tincan import Activity, ActivityDefinition, Agent, LanguageMap
 
-from eox_nelp.openedx_filters.xapi.filters import DEFAULT_LANGUAGE, XApiActorFilter, XApiBaseEnrollmentFilter
+from eox_nelp.edxapp_wrapper.modulestore import modulestore
+from eox_nelp.openedx_filters.xapi.filters import (
+    DEFAULT_LANGUAGE,
+    XApiActorFilter,
+    XApiBaseEnrollmentFilter,
+    XApiBaseProblemsFilter,
+)
 
 User = get_user_model()
 
@@ -155,3 +163,140 @@ class XApiBaseEnrollmentFilterTestCase(TestCase):
         self.assertEqual({DEFAULT_LANGUAGE: course["display_name"]}, returned_activity.definition.name)
         self.assertEqual({DEFAULT_LANGUAGE: course["short_description"]}, returned_activity.definition.description)
         get_course_mock.assert_called_once_with("course-v1:edx+CS105+2023-T3")
+
+
+@ddt
+class XApiBaseProblemsFilterTestCase(TestCase):
+    """Test class for XApiBaseProblemsFilterr filter class."""
+
+    def setUp(self):
+        """Setup common conditions for every test case"""
+        self.default_values = {
+            "display_name": "testing-course",
+            "data.problem_id": "block-v1:edx+CS105+2023-T3+type@problem+block@0221040b086c4618b6b2b2a554558",
+            "course_id": "course-v1:edx+CS105+2023-T3",
+        }
+        self.filter = XApiBaseProblemsFilter(
+            filter_type="event_routing_backends.processors.xapi.problem_interaction_events.base_problems.get_object",
+            running_pipeline=["eox_nelp.openedx_filters.xapi.filters.XApiBaseProblemsFilter"],
+        )
+        self.transformer = Mock()
+        self.transformer.event = {"name": "edx.grades.problem.submitted"}
+        self.transformer.get_data.side_effect = lambda x: self.default_values[x]
+        self.transformer._get_submission.return_value = {}  # pylint: disable=protected-access
+        self.course = {"language": "ar"}
+        self.activity = Activity(
+            id="https://example.com/xblock/block-v1:edx+CS105+2023-T3+type@problem+block@0221040b086c4618b6b2b2a554558",
+            definition=ActivityDefinition(
+                type="http://adlnet.gov/expapi/activities/question",
+                name=LanguageMap(en="old-testing-course"),
+            ),
+        )
+
+        item = Mock()
+        item.markdown = ""
+        modulestore.return_value.get_item.return_value = item
+
+    def tearDown(self):
+        """Restore mocks' state"""
+        modulestore.reset_mock()
+        self.transformer.reset_mock()
+
+    @data(None, "")
+    @patch("eox_nelp.openedx_filters.xapi.filters.get_course_from_id")
+    def test_invalid_display_name(self, display_name, get_course_mock):  # pylint: disable=unused-argument
+        """ Test case when display_name is None or an empty string.
+
+        Expected behavior:
+            - Definition name wasn't updated.
+        """
+        course_name = "testing-course"
+        get_course_mock.return_value = self.course
+
+        # Set results of get_data method.
+        self.default_values["display_name"] = display_name
+        self.transformer.get_data.side_effect = lambda x: self.default_values[x]
+
+        # Set input arguments.
+        self.activity.definition.name = LanguageMap(en=course_name)
+
+        returned_activity = self.filter.run_filter(transformer=self.transformer, result=self.activity)["result"]
+
+        self.assertEqual({DEFAULT_LANGUAGE: course_name}, returned_activity.definition.name)
+
+    @patch("eox_nelp.openedx_filters.xapi.filters.get_course_from_id")
+    def test_valid_display_name(self, get_course_mock):
+        """ Test case when display_name is found and valid.
+
+        Expected behavior:
+            - Definition name has been updated.
+        """
+        get_course_mock.return_value = self.course
+
+        returned_activity = self.filter.run_filter(transformer=self.transformer, result=self.activity)["result"]
+
+        self.assertEqual(
+            {self.course['language']: self.default_values["display_name"]},
+            returned_activity.definition.name,
+        )
+
+    @patch("eox_nelp.openedx_filters.xapi.filters.get_course_from_id")
+    def test_update_description(self, get_course_mock):
+        """ Test case when item label is valid and the description is updated.
+
+        Expected behavior:
+            - Definition description has been updated.
+        """
+        item = Mock()
+        label = "This is a great label"
+        item.markdown = f">>{label}<<"
+        modulestore.return_value.get_item.return_value = item
+        get_course_mock.return_value = self.course
+
+        returned_activity = self.filter.run_filter(transformer=self.transformer, result=self.activity)["result"]
+
+        self.assertEqual(
+            {self.course['language']: label},
+            returned_activity.definition.description,
+        )
+
+    @patch("eox_nelp.openedx_filters.xapi.filters.get_course_from_id")
+    def test_empty_label(self, get_course_mock):
+        """ Test case when the item markdown doesn't contain a label.
+
+        Expected behavior:
+            - Definition description is an empty dict.
+        """
+        get_course_mock.return_value = self.course
+
+        returned_activity = self.filter.run_filter(transformer=self.transformer, result=self.activity)["result"]
+
+        self.assertEqual({}, returned_activity.definition.description)
+
+    @patch("eox_nelp.openedx_filters.xapi.filters.get_course_from_id")
+    def test_default_language(self, get_course_mock):
+        """ Test case when the course has no language or is not valid.
+
+        Expected behavior:
+            - Definition name has the default key language.
+        """
+        get_course_mock.return_value = {}
+
+        returned_activity = self.filter.run_filter(transformer=self.transformer, result=self.activity)["result"]
+
+        self.assertEqual([DEFAULT_LANGUAGE], list(returned_activity.definition.name.keys()))
+
+    def test_invalid_event(self):
+        """ Test case when the event name is different from edx.grades.problem.submitted.
+
+        Expected behavior:
+            - Returned activity is the same input activity.
+        """
+        self.transformer.event = {"name": "other-event"}
+        activity = Activity(
+            id="empty-activity",
+        )
+
+        returned_activity = self.filter.run_filter(transformer=self.transformer, result=activity)["result"]
+
+        self.assertEqual(activity, returned_activity)

--- a/eox_nelp/utils.py
+++ b/eox_nelp/utils.py
@@ -119,3 +119,26 @@ def get_course_from_id(course_id):
         return course_overviews[0]
 
     raise ValueError(f"Course with id {course_id} does not exist.")
+
+
+def get_item_label(item):
+    """By definition the label of a Problem is the text between double greater and lees than
+    symbols, example, >>label<<, this method extracts and returns that information from the item
+    markdown value.
+
+    Arguments:
+        item <XModuleDescriptor>: This is a specification for an element of a course.
+            This case should be a problem.
+    Returns:
+        label <string>: Label data if it's found otherwise empty string.
+    """
+    if not hasattr(item, "markdown"):
+        return ""
+
+    regex = re.compile(r'>>\s*(.*?)\s*<<')
+    matches = regex.search(item.markdown)
+
+    if matches:
+        return matches.group(1)
+
+    return ""


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This implements a filter that allows to update the event edx.grades.problem.submitted

## Testing instructions

Default setting doesn't work, use the following:

```
EVENT_TRACKING_BACKENDS["xapi"] = {
    "ENGINE": "eventtracking.backends.async_routing.AsyncRoutingBackend",
    "OPTIONS": {
        "backend_name": "xapi",
        "processors": [
            {
                "ENGINE": "eventtracking.processors.whitelist.NameWhitelistProcessor",
                "OPTIONS": {
                    "whitelist": [
                        "edx.grades.problem.submitted",                   
                    ]
                }
            }
        ],
        "backends": {
            "xapi": {
                "ENGINE": "event_routing_backends.backends.events_router.EventsRouter",
                "OPTIONS": {
                    "processors": [
                        {
                            "ENGINE": "event_routing_backends.processors.xapi.transformer_processor.XApiProcessor",
                            "OPTIONS": {}
                        }
                    ],
                    "backend_name": "xapi"
                }
            }
        }
    }
}
```

1. Use this version of event routing https://github.com/nelc/event-routing-backends/pull/5
2. add the settings        
```
        OPEN_EDX_FILTERS_CONFIG = {
            "event_routing_backends.processors.xapi.problem_interaction_events.base_problems.get_object": {
                "pipeline": ["eox_nelp.openedx_filters.xapi.filters.XApiBaseProblemsFilter"],
                "fail_silently": False,
            },
        }
```
3. Submit any answer in a problem like checkboxes
4. Check the result, in my case I'm using aspects, so I can check that in the superset panel
 
### Before
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/ea6754e4-ae76-4cf6-9b4a-8fbcf35ef526)

### After

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/aca35989-c258-4aef-bc1e-df86cd59a520)


## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
