### PR TITLE
feat: add receiver which is able to emit an event the first time that…

### DIFF
--- a/eox_nelp/apps.py
+++ b/eox_nelp/apps.py
@@ -42,6 +42,12 @@ class EoxNelpConfig(AppConfig):
                         'sender_path': 'completion.models.BlockCompletion',
                     },
                     {
+                        'receiver_func_name': 'emit_initialized_course_event',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'dispatch_uid': 'emit_initialized_course_event_receviver',
+                        'sender_path': 'completion.models.BlockCompletion',
+                    },
+                    {
                         'receiver_func_name': 'course_grade_changed_progress_publisher',
                         'signal_path': 'openedx.core.djangoapps.signals.signals.COURSE_GRADE_CHANGED',
                         'dispatch_uid': 'course_grade_publisher_receiver',

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -12,6 +12,7 @@ edx-opaque-keys
 eox-core
 eox-tenant
 eox-theming
+event-tracking
 mako
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -170,7 +170,9 @@ eox-tenant==9.2.1
 eox-theming==5.0.0
     # via -r requirements/base.in
 event-tracking==2.2.0
-    # via edx-proctoring
+    # via
+    #   -r requirements/base.in
+    #   edx-proctoring
 fastavro==1.9.0
     # via openedx-events
 fs==2.4.16


### PR DESCRIPTION


<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

 Add receiver which is able to emit an event the first time that a user completes problem.

https://edunext.atlassian.net/browse/FUTUREX-644

## Testing instructions
- create a course with some units
- complete one unit 
-  look for the `nelc.eox_nelp.initialized.course` in the logs

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/2d19009f-e32b-4292-a445-0ff7198983ec)

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
