### PR TITLE
feat: add course experience transformer

### DIFF
--- a/eox_nelp/processors/tests/xapi/event_transformers/tests_course_experience_events.py
+++ b/eox_nelp/processors/tests/xapi/event_transformers/tests_course_experience_events.py
@@ -1,0 +1,87 @@
+"""This file contains all the test for the course_experience_events.py file.
+
+Classes:
+    FeedBackCourseTransformerTestCase: Tests cases for FeedBackCourseTransformer class.
+    FeedBackUnitTransformerTestCase: Tests cases for FeedBackUnitTransformer class.
+"""
+from django.test import TestCase
+from mock import call
+from tincan import LanguageMap, Result
+
+from eox_nelp.edxapp_wrapper.event_routing_backends import constants
+from eox_nelp.processors.tests.xapi.mixins import BaseCourseObjectTestCaseMixin, BaseModuleObjectTestCaseMixin
+from eox_nelp.processors.xapi import constants as eox_nelp_constants
+from eox_nelp.processors.xapi.event_transformers import FeedBackCourseTransformer, FeedBackUnitTransformer
+
+
+class BaseFeedBackTransformerTestCase:
+    """Base class that contains all the common feedback test cases"""
+
+    def test_verb_attribute(self):
+        """ Test case that checks that the _verb attribute has the right values.
+
+        Expected behavior:
+            - Verb id is the expected value.
+            - Verb display is the expected value.
+        """
+        verb = self.transformer_class._verb  # pylint: disable=protected-access,no-member
+
+        # pylint: disable=no-member
+        self.assertEqual(eox_nelp_constants.XAPI_VERB_RATED, verb.id)
+        self.assertEqual(LanguageMap({constants.EN: eox_nelp_constants.RATED}), verb.display)
+
+    def test_get_result_method(self):
+        """Test case that checks that the course_id property has been overridden and returns the expected value.
+
+        Expected behavior:
+            - result is the expected value.
+            - get_data has been called twice with the right parameters.
+        """
+        rating_content = "4"
+        feedback = "This is a great activity"
+        min_score = eox_nelp_constants.MIN_FEEDBACK_SCORE
+        max_score = eox_nelp_constants.MAX_FEEDBACK_SCORE
+        self.transformer_class.get_data.side_effect = [rating_content, feedback]  # pylint: disable=no-member
+        transformer = self.transformer_class()  # pylint: disable=no-member
+        expected_result = Result(
+            score={
+                "scaled": int(rating_content) / max_score,
+                "raw": int(rating_content),
+                "min": min_score,
+                "max": max_score,
+            },
+            response=feedback,
+        )
+
+        result = transformer.get_result()
+
+        # pylint: disable=no-member
+        self.assertEqual(expected_result, result)
+        self.assertEqual(
+            [call("data.rating_content"), call("data.feedback")],
+            self.transformer_class.get_data.call_args_list,
+        )
+
+
+class FeedBackCourseTransformerTestCase(BaseCourseObjectTestCaseMixin, BaseFeedBackTransformerTestCase, TestCase):
+    """Test class for FeedBackCourseTransformer class."""
+    transformer_class = FeedBackCourseTransformer
+
+
+class FeedBackUnitTransformerTestCase(BaseModuleObjectTestCaseMixin, BaseFeedBackTransformerTestCase, TestCase):
+    """Test class for FeedBackUnitTransformer class."""
+    transformer_class = FeedBackUnitTransformer
+
+    def test_item_id_property(self):
+        """Test case that checks that the item_id property has been overridden and returns the expected value.
+
+        Expected behavior:
+            - item_id is the expected value.
+            - get_data has been called with the right parameters.
+        """
+        item_id = "block-v1:edx+CS104+2023+type@vertical+block@cbf124449a7a46cd82270b6051d6e902"
+        self.transformer_class.get_data.return_value = item_id
+        transformer = self.transformer_class()
+
+        self.assertEqual(item_id, transformer.item_id)
+        self.transformer_class.get_data.assert_called_once_with("data.item_id", required=True)

--- a/eox_nelp/processors/tests/xapi/event_transformers/tests_initialized_events.py
+++ b/eox_nelp/processors/tests/xapi/event_transformers/tests_initialized_events.py
@@ -26,17 +26,3 @@ class InitializedCourseTransformerTestCase(BaseCourseObjectTestCaseMixin, TestCa
 
         self.assertEqual(constants.XAPI_VERB_INITIALIZED, verb.id)
         self.assertEqual(LanguageMap({constants.EN: constants.INITIALIZED}), verb.display)
-
-    def test_course_id_property(self):
-        """Test case that checks that the course_id property has been overridden and returns the expected value.
-
-        Expected behavior:
-            - course_id is the expected value.
-            - get_data has been called with the right parameters.
-        """
-        course_id = "course-v1:edx+CS105+2023-T3"
-        self.transformer_class.get_data.return_value = course_id
-        transformer = self.transformer_class()
-
-        self.assertEqual(course_id, transformer.course_id)
-        self.transformer_class.get_data.assert_called_once_with("data.course_id", required=True)

--- a/eox_nelp/processors/tests/xapi/mixins.py
+++ b/eox_nelp/processors/tests/xapi/mixins.py
@@ -2,10 +2,14 @@
 
 Classes:
     BaseCourseObjectTestCaseMixin: Test mixin for children classes of BaseCourseObjectTransformerMixin.
+    BaseModuleObjectTestCaseMixin: Test mixin for children classes of BaseModuleObjectTransformerMixin.
 """
-from mock import patch
+from mock import Mock, call, patch
+from opaque_keys.edx.keys import UsageKey
 from tincan import ActivityDefinition, LanguageMap
 
+from eox_nelp.edxapp_wrapper.event_routing_backends import constants
+from eox_nelp.edxapp_wrapper.modulestore import modulestore
 from eox_nelp.processors.xapi import constants as eox_nelp_constants
 
 
@@ -15,7 +19,22 @@ class BaseCourseObjectTestCaseMixin:
     def tearDown(self):  # pylint: disable=invalid-name
         """Reset mocks"""
         self.transformer_class.get_data.reset_mock()
+        self.transformer_class.get_data.side_effect = None
         self.transformer_class.get_object_iri.reset_mock()
+
+    def test_course_id_property(self):
+        """Test case that checks that the course_id property has been overridden and returns the expected value.
+
+        Expected behavior:
+            - course_id is the expected value.
+            - get_data has been called with the right parameters.
+        """
+        course_id = "course-v1:edx+CS105+2023-T3"
+        self.transformer_class.get_data.return_value = course_id
+        transformer = self.transformer_class()
+
+        self.assertEqual(course_id, transformer.course_id)
+        self.transformer_class.get_data.assert_called_once_with("data.course_id", required=True)
 
     @patch("eox_nelp.processors.xapi.mixins.get_course_from_id")
     def test_get_object_method(self, get_course_mock):
@@ -52,6 +71,85 @@ class BaseCourseObjectTestCaseMixin:
                 type=eox_nelp_constants.XAPI_ACTIVITY_COURSE,
                 name=LanguageMap({course["language"]: course["display_name"]}),
                 description=LanguageMap({course["language"]: course["short_description"]}),
+            ),
+            activity.definition,
+        )
+
+
+class BaseModuleObjectTestCaseMixin:
+    """This is a test mixin for classes which implements the BaseModuleObjectTransformerMixin class."""
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Reset mocks"""
+        self.transformer_class.get_data.reset_mock()
+        self.transformer_class.get_data.side_effect = None
+        self.transformer_class.get_object_iri.reset_mock()
+        modulestore.return_value.get_item.reset_mock()
+
+    def test_course_id_property(self):
+        """Test case that checks that the course_id property has been overridden and returns the expected value.
+
+        Expected behavior:
+            - course_id is the expected value.
+            - get_data has been called with the right parameters.
+        """
+        course_id = "course-v1:edx+CS247+2024-T3"
+        self.transformer_class.get_data.return_value = course_id
+        transformer = self.transformer_class()
+
+        self.assertEqual(course_id, transformer.course_id)
+        self.transformer_class.get_data.assert_called_once_with("data.course_id", required=True)
+
+    @patch("eox_nelp.processors.xapi.mixins.get_course_from_id")
+    def test_get_object_method(self, get_course_mock):
+        """ Test case that verifies that the get_object method returns the expected Activity
+        when all the course attributes are found.
+
+        Expected behavior:
+            - Activity id is the expected value.
+            - get_course_from_id method is called with the right value.
+            - get_object_iri method is called with the right value.
+            - modulestore get_item methods is called with the right value
+            - get_data method is called twice with right values.
+            - Activity definition is the expected value.
+        """
+        # Set get_data returned values
+        course_id = "course-v1:edx+CS105+2023-T3"
+        item_id = "block-v1:edx+CS104+2023+type@vertical+block@cbf124449a7a46cd82270b6051d6e902"
+        self.transformer_class.get_data.side_effect = [item_id, course_id]
+
+        # Set modulestore mock
+        item = Mock()
+        item.display_name = "Unit"
+        modulestore.return_value.get_item.return_value = item
+
+        # Set get_object_iri mock
+        object_id = f"http://example.com/xblock/{item_id}"
+        self.transformer_class.get_object_iri.return_value = object_id
+
+        # Set get_course_from_id mock
+        course = {
+            "language": "fr",
+        }
+        get_course_mock.return_value = course
+
+        # Initialize test class
+        transformer = self.transformer_class()
+
+        activity = transformer.get_object()
+
+        self.assertEqual(object_id, activity.id)
+        get_course_mock.assert_called_once_with(course_id)
+        self.transformer_class.get_object_iri.assert_called_once_with("xblock", item_id)
+        modulestore.return_value.get_item.assert_called_once_with(UsageKey.from_string(item_id))
+        self.assertEqual(
+            [call("data.item_id", required=True), call("data.course_id", required=True)],
+            self.transformer_class.get_data.call_args_list,
+        )
+        self.assertEqual(
+            ActivityDefinition(
+                type=constants.XAPI_ACTIVITY_MODULE,
+                name=LanguageMap({course["language"]: item.display_name}),
             ),
             activity.definition,
         )

--- a/eox_nelp/processors/tests/xapi/tests_mixins.py
+++ b/eox_nelp/processors/tests/xapi/tests_mixins.py
@@ -2,10 +2,11 @@
 
 Classes:
     BaseCourseObjectTransformerMixinTestCase: Test class for BaseCourseObjectTransformerMixin class.
+    BaseModuleObjectTransformerMixinTestCase: Test class for BaseModuleObjectTransformerMixin class.
 """
 from django.test import TestCase
 
-from eox_nelp.processors.xapi.mixins import BaseCourseObjectTransformerMixin
+from eox_nelp.processors.xapi.mixins import BaseCourseObjectTransformerMixin, BaseModuleObjectTransformerMixin
 
 
 class BaseCourseObjectTransformerMixinTestCase(TestCase):
@@ -22,3 +23,31 @@ class BaseCourseObjectTransformerMixinTestCase(TestCase):
 
         with self.assertRaises(NotImplementedError):
             mixin.course_id  # pylint: disable=pointless-statement
+
+
+class BaseModuleObjectTransformerMixinTestCase(TestCase):
+    """Test class for BaseModuleObjectTransformerMixin class."""
+
+    def test_course_id_not_set(self):
+        """ Test case that checks that the exception NotImplementedError is raised
+        when the course_id property has not been overridden.
+
+        Expected behavior:
+            - NotImplementedError exception is raised
+        """
+        mixin = BaseModuleObjectTransformerMixin()
+
+        with self.assertRaises(NotImplementedError):
+            mixin.course_id  # pylint: disable=pointless-statement
+
+    def test_item_id_not_set(self):
+        """ Test case that checks that the exception NotImplementedError is raised
+        when the item_id property has not been overridden.
+
+        Expected behavior:
+            - NotImplementedError exception is raised
+        """
+        mixin = BaseModuleObjectTransformerMixin()
+
+        with self.assertRaises(NotImplementedError):
+            mixin.item_id  # pylint: disable=pointless-statement

--- a/eox_nelp/processors/xapi/constants.py
+++ b/eox_nelp/processors/xapi/constants.py
@@ -1,6 +1,12 @@
 """
 Constants for xAPI specifications, this contains the NELC required values.
 """
+from eox_nelp.course_experience.models import RATING_OPTIONS
+
 DEFAULT_LANGUAGE = "en"
+RATED = "rated"
+MAX_FEEDBACK_SCORE = RATING_OPTIONS[-1][0]
+MIN_FEEDBACK_SCORE = 0
 
 XAPI_ACTIVITY_COURSE = "https://w3id.org/xapi/cmi5/activitytype/course"
+XAPI_VERB_RATED = "http://id.tincanapi.com/verb/rated"

--- a/eox_nelp/processors/xapi/event_transformers/__init__.py
+++ b/eox_nelp/processors/xapi/event_transformers/__init__.py
@@ -1,4 +1,8 @@
 """
 All xAPI transformers.
 """
+from eox_nelp.processors.xapi.event_transformers.course_experience_events import (  # noqa: F401
+    FeedBackCourseTransformer,
+    FeedBackUnitTransformer,
+)
 from eox_nelp.processors.xapi.event_transformers.initialized_events import InitializedCourseTransformer  # noqa: F401

--- a/eox_nelp/processors/xapi/event_transformers/course_experience_events.py
+++ b/eox_nelp/processors/xapi/event_transformers/course_experience_events.py
@@ -1,0 +1,82 @@
+"""
+Transformers for course experience events.
+
+Classes:
+    FeedBackCourseTransformer: Transformer for the event nelc.eox_nelp.course_experience.feedback_course
+    FeedBackUnitTransformer: Transformer for the event nelc.eox_nelp.course_experience.feedback_unit
+"""
+from django.utils.functional import cached_property
+from tincan import LanguageMap, Result, Verb
+
+from eox_nelp.edxapp_wrapper.event_routing_backends import XApiTransformer, XApiTransformersRegistry, constants
+from eox_nelp.processors.xapi import constants as eox_nelp_constants
+from eox_nelp.processors.xapi.mixins import BaseCourseObjectTransformerMixin, BaseModuleObjectTransformerMixin
+
+
+class BaseFeedBackTransformer(XApiTransformer):
+    """
+    Base transformer for feedback events.
+    """
+    _verb = Verb(
+        id=eox_nelp_constants.XAPI_VERB_RATED,
+        display=LanguageMap({constants.EN: eox_nelp_constants.RATED}),
+    )
+    additional_fields = ('result', )
+
+    def get_result(self):
+        """
+        Get result for xAPI transformed event.
+
+        Returns:
+            `Result`
+        """
+        min_score = eox_nelp_constants.MIN_FEEDBACK_SCORE
+        max_score = eox_nelp_constants.MAX_FEEDBACK_SCORE
+        raw_score = int(self.get_data("data.rating_content") or min_score)
+        scaled = raw_score / max_score
+
+        return Result(
+            score={
+                "scaled": scaled,
+                "raw": raw_score,
+                "min": min_score,
+                "max": max_score,
+            },
+            response=self.get_data("data.feedback") or ""
+        )
+
+
+@XApiTransformersRegistry.register("nelc.eox_nelp.course_experience.feedback_course")
+class FeedBackCourseTransformer(BaseCourseObjectTransformerMixin, BaseFeedBackTransformer):
+    """
+    Transformers for generated event when an student rates a course.
+    """
+    @cached_property
+    def course_id(self):
+        """
+        Transformer's property that returns the associated
+        course id for the `nelc.eox_nelp.course_experience.feedback_course` event.
+        """
+        return self.get_data('data.course_id', required=True)
+
+
+@XApiTransformersRegistry.register("nelc.eox_nelp.course_experience.feedback_unit")
+class FeedBackUnitTransformer(BaseModuleObjectTransformerMixin, BaseFeedBackTransformer):
+    """
+    Transformers for generated event when an student rates an unit.
+    """
+    @cached_property
+    def course_id(self):
+        """
+        Transformer's property that returns the associated
+        course id for the `nelc.eox_nelp.course_experience.feedback_unit` event.
+        """
+        return self.get_data('data.course_id', required=True)
+
+    @cached_property
+    def item_id(self):
+        """
+        Transformer's property that returns the associated
+        item id for the `nelc.eox_nelp.course_experience.feedback_unit` event.
+        """
+        return self.get_data('data.item_id', required=True)

--- a/eox_nelp/processors/xapi/mixins.py
+++ b/eox_nelp/processors/xapi/mixins.py
@@ -4,8 +4,11 @@ Classes:
     - BaseCourseObjectTransformerMixin: Base mixin for transformers that has as object an edx-platform course
 """
 from django.utils.functional import cached_property
+from opaque_keys.edx.keys import UsageKey
 from tincan import Activity, ActivityDefinition, LanguageMap
 
+from eox_nelp.edxapp_wrapper.event_routing_backends import constants
+from eox_nelp.edxapp_wrapper.modulestore import modulestore
 from eox_nelp.processors.xapi import constants as eox_nelp_constants
 from eox_nelp.utils import get_course_from_id
 
@@ -43,5 +46,52 @@ class BaseCourseObjectTransformerMixin:
                 type=eox_nelp_constants.XAPI_ACTIVITY_COURSE,
                 name=LanguageMap(**({course_language: display_name} if display_name is not None else {})),
                 description=LanguageMap(**({course_language: description} if description is not None else {})),
+            ),
+        )
+
+
+class BaseModuleObjectTransformerMixin:
+    """
+    Base mixin for transformers that has as object an edx-platform module(chapter, sequential, vertical, component).
+    """
+    @cached_property
+    def course_id(self):
+        """The course id data depends on the kind of event, an event could publish this as course_id or course_key
+        so this a wrapper that should be implemented in order to use the get_object method.
+
+        Raises:
+            NotImplementedError: when the subclass has not overridden the course_id property.
+        """
+        raise NotImplementedError
+
+    @cached_property
+    def item_id(self):
+        """The item id data depends on the kind of event, an event could publish this as course_id or course_key
+        so this a wrapper that should be implemented in order to use the get_object method.
+
+        Raises:
+            NotImplementedError: when the subclass has not overridden the course_id property.
+        """
+        raise NotImplementedError
+
+    def get_object(self):
+        """
+        Get object for xAPI transformed event.
+
+        Returns:
+            `Activity`
+        """
+        item = modulestore().get_item(UsageKey.from_string(self.item_id))
+        display_name = item.display_name
+
+        course = get_course_from_id(self.course_id)
+        # Set default value if language is not found
+        course_language = course["language"] or eox_nelp_constants.DEFAULT_LANGUAGE
+
+        return Activity(
+            id=self.get_object_iri("xblock", self.item_id),
+            definition=ActivityDefinition(
+                type=constants.XAPI_ACTIVITY_MODULE,
+                name=LanguageMap(**({course_language: display_name} if display_name is not None else {})),
             ),
         )


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This pr adds new transformers for the events added in this [pr](https://github.com/eduNEXT/eox-nelp/pull/115)  the whole functionality depends on the previous pr however the code doesn't that's why this was not rebased over the code of the pr 115

## Testing instructions

1.  Ensure that you have the changes of the pr 115
2. Generate an event, use as guide the instructions of the pr 115 
3.  Verify the data that was sent, I use aspects



### Unit result
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/925d2fc8-9385-493b-9a98-1f0c334d8739)

### Course result
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/29417852-41c8-475f-8e60-d2a9412a343d)


## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
