### PR TITLE
feat: Add verb filter and updates default language

### DIFF
--- a/eox_nelp/processors/xapi/constants.py
+++ b/eox_nelp/processors/xapi/constants.py
@@ -3,7 +3,7 @@ Constants for xAPI specifications, this contains the NELC required values.
 """
 from eox_nelp.course_experience.models import RATING_OPTIONS
 
-DEFAULT_LANGUAGE = "en"
+DEFAULT_LANGUAGE = "en-US"
 RATED = "rated"
 MAX_FEEDBACK_SCORE = RATING_OPTIONS[-1][0]
 MIN_FEEDBACK_SCORE = 0


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description
This updates the eox-nelp default language  in order to use that value on the filters where that constant is used, on the other hand implements a filter that update the verb language key

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/bd1aeb29-5895-4de9-b638-511c3797a428)

## Testing instructions

1. Set filter settings
```
        OPEN_EDX_FILTERS_CONFIG = {
            "event_routing_backends.processors.xapi.enrollment_events.base_enrollment.get_object": {
                "pipeline": ["eox_nelp.openedx_filters.xapi.filters.XApiBaseEnrollmentFilter"],
                "fail_silently": False,
            },
        }
```
2. Raise an event
3. Confirm verb dispaly key


## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
