### PR TITLE
refactor!: generalize XApiBaseProblemsFilter to support module and qu…

### DIFF
--- a/eox_nelp/edxapp_wrapper/test_backends/event_routing_backends_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/event_routing_backends_m_v1.py
@@ -17,6 +17,8 @@ def get_xapi_constants():
     constants.XAPI_VERB_INITIALIZED = "http://adlnet.gov/expapi/verbs/initialized"
     constants.XAPI_ACTIVITY_COURSE = "http://adlnet.gov/expapi/activities/course"
     constants.INITIALIZED = "initialized"
+    constants.XAPI_ACTIVITY_MODULE = "http://adlnet.gov/expapi/activities/module"
+    constants.XAPI_ACTIVITY_QUESTION = "http://adlnet.gov/expapi/activities/question"
 
     return constants
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This is a refactor in order to use the same filter for objects with definition type equals to module or question


## Testing instructions

1. Set the right setting, the doc string was update with a new version that includes more filters
2. Generate the event, you could attempt any problem
3. check the result

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/4738c151-e54f-4a7d-a80c-f7173315cc9b)


### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
