### PR TITLE
fix: get display name from module descriptor instead of tracker context

### DIFF
--- a/eox_nelp/openedx_filters/tests/xapi/tests_filters.py
+++ b/eox_nelp/openedx_filters/tests/xapi/tests_filters.py
@@ -195,7 +195,6 @@ class XApiModuleQuestionObjectFilterTestCase(TestCase):
     def setUp(self):
         """Setup common conditions for every test case"""
         self.default_values = {
-            "display_name": "testing-course",
             "data.problem_id": "block-v1:edx+CS105+2023-T3+type@problem+block@0221040b086c4618b6b2b2a554558",
             "course_id": "course-v1:edx+CS105+2023-T3",
         }
@@ -210,9 +209,10 @@ class XApiModuleQuestionObjectFilterTestCase(TestCase):
         self.course = {"language": "ar"}
         self.activity = None
 
-        item = Mock()
-        item.markdown = ""
-        modulestore.return_value.get_item.return_value = item
+        self.item = Mock()
+        self.item.markdown = ""
+        self.item.display_name = "testing-course"
+        modulestore.return_value.get_item.return_value = self.item
 
     def tearDown(self):
         """Restore mocks' state"""
@@ -248,7 +248,7 @@ class XApiModuleQuestionObjectFilterTestCase(TestCase):
         self.set_activity(definition_type)
 
         # Set results of get_data method.
-        self.default_values["display_name"] = display_name
+        self.item.display_name = display_name
         self.transformer.get_data.side_effect = lambda x: self.default_values[x]
 
         # Set input arguments.
@@ -272,7 +272,7 @@ class XApiModuleQuestionObjectFilterTestCase(TestCase):
         returned_activity = self.filter.run_filter(transformer=self.transformer, result=self.activity)["result"]
 
         self.assertEqual(
-            {self.course['language']: self.default_values["display_name"]},
+            {self.course['language']: self.item.display_name},
             returned_activity.definition.name,
         )
 
@@ -287,6 +287,7 @@ class XApiModuleQuestionObjectFilterTestCase(TestCase):
         item = Mock()
         label = "This is a great label"
         item.markdown = f">>{label}<<"
+        item.display_name = None
         modulestore.return_value.get_item.return_value = item
         get_course_mock.return_value = self.course
         self.set_activity(definition_type)

--- a/eox_nelp/openedx_filters/xapi/filters.py
+++ b/eox_nelp/openedx_filters/xapi/filters.py
@@ -145,12 +145,11 @@ class XApiModuleQuestionObjectFilter(PipelineStep):
             Activity: Modified activity.
         """
         if result.definition.type in [constants.XAPI_ACTIVITY_QUESTION, constants.XAPI_ACTIVITY_MODULE]:
-            display_name = transformer.get_data('display_name')
-
-            # Get label from module descriptor block.
+            # Get component data from module descriptor block.
             usage_id = transformer.get_data("data.problem_id") or transformer.get_data("data.block_id")
             usage_key = UsageKey.from_string(usage_id)
             item = modulestore().get_item(usage_key)
+            display_name = item.display_name
             label = get_item_label(item)
 
             # Get course languge block.


### PR DESCRIPTION
## Description

This pr considers two things

1. the line `transformer.get_data('display_name')` obtains the value from the tracker [context](https://github.com/openedx/event-tracking/blob/706ac528d86962d5d4dedda992f609a06db042ff/eventtracking/tracker.py#L41)  however that context is not updated for the completion-aggregator library when the event is emitted  so as you can see in the following images  the context is the same for problems, verticals, sequentials and chapters 

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/6d912295-732f-4525-8275-a1cfcca07f04)

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/7144531b-3508-440d-857c-ac9ff211e58e)

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/4345c1e7-3b8e-4ac1-8977-5304fb74809b)

After these changes the result is the following

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/d3040af9-8742-4f8d-b967-11639968c6bb)

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/af3b7629-9f20-4517-add6-412cd701dcb8)
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/3be793c3-bf0a-4b75-951b-ae014323a3fd)

2. Even if the context were updated that context just works on synchronous processes so this implementation contemplates async tasks


## Testing instructions

### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
