### PR TITLE
Jlc/palm mig/language middleware

### DIFF
--- a/eox_nelp/middleware.py
+++ b/eox_nelp/middleware.py
@@ -5,6 +5,9 @@ Required NELP middlewares that allow to customize edx-platform.
 classes:
     ExtendedProfileFieldsMiddleware: Set extended_profile_fields in registration form.
 """
+from django.conf import settings
+from django.http import parse_cookie
+from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import gettext_lazy as _
 
 from eox_nelp.edxapp_wrapper.site_configuration import configuration_helpers
@@ -133,3 +136,21 @@ class ExtendedProfileFieldsMiddleware:
             # pylint: disable=protected-access
             form_instance._add_field_with_configurable_select_options(field, label, form_desc, required=required)
         return handler
+
+
+class PreserveUserLanguageCookieMiddleware(MiddlewareMixin):
+    """This middleware ensure that in the COOKIES property the LANGUAGE_COOKIE_NAME
+    key has to be the cookie sent by the user and not other,
+    because it could be modified previously by other.
+    eg.
+    https://github.com/openedx/edx-platform/blob/open-release/palm.master/openedx/
+    core/djangoapps/lang_pref/middleware.py#L61-L62
+    """
+    def process_request(self, request):
+        """Process the request to change the language cookie based in original cookie value."""
+        original_user_language_cookie = parse_cookie(request.META.get("HTTP_COOKIE", "")).get(
+            settings.LANGUAGE_COOKIE_NAME
+        )
+
+        if original_user_language_cookie:
+            request.COOKIES[settings.LANGUAGE_COOKIE_NAME] = original_user_language_cookie

--- a/eox_nelp/middleware.py
+++ b/eox_nelp/middleware.py
@@ -7,7 +7,6 @@ classes:
 """
 from django.conf import settings
 from django.http import parse_cookie
-from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import gettext_lazy as _
 
 from eox_nelp.edxapp_wrapper.site_configuration import configuration_helpers
@@ -138,7 +137,7 @@ class ExtendedProfileFieldsMiddleware:
         return handler
 
 
-class PreserveUserLanguageCookieMiddleware(MiddlewareMixin):
+class PreserveUserLanguageCookieMiddleware:
     """This middleware ensure that in the COOKIES property the LANGUAGE_COOKIE_NAME
     key has to be the cookie sent by the user and not other,
     because it could be modified previously by other.
@@ -146,7 +145,10 @@ class PreserveUserLanguageCookieMiddleware(MiddlewareMixin):
     https://github.com/openedx/edx-platform/blob/open-release/palm.master/openedx/
     core/djangoapps/lang_pref/middleware.py#L61-L62
     """
-    def process_request(self, request):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
         """Process the request to change the language cookie based in original cookie value."""
         original_user_language_cookie = parse_cookie(request.META.get("HTTP_COOKIE", "")).get(
             settings.LANGUAGE_COOKIE_NAME
@@ -154,3 +156,5 @@ class PreserveUserLanguageCookieMiddleware(MiddlewareMixin):
 
         if original_user_language_cookie:
             request.COOKIES[settings.LANGUAGE_COOKIE_NAME] = original_user_language_cookie
+
+        return self.get_response(request)

--- a/eox_nelp/middleware.py
+++ b/eox_nelp/middleware.py
@@ -4,6 +4,7 @@ Required NELP middlewares that allow to customize edx-platform.
 
 classes:
     ExtendedProfileFieldsMiddleware: Set extended_profile_fields in registration form.
+    PreserveUserLanguageCookieMiddleware: Set the LANGUAGE cookie name with the original cookie sent by user.
 """
 from django.conf import settings
 from django.http import parse_cookie


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

Migrate the language per cookie usage from edx-platform to plugin.

This was inspired in the `COOKIES` manipulation by django.https://github.com/django/django/blob/main/django/core/handlers/wsgi.py#L100-L102
## Testing instructions
1. Checkout you edx-platform to `open-release/palm.nelp`.

2. Install eox-nelp using this branch or using editable way.
eg
```
pip install git+https://github.com/eduNEXT/eox-nelp.git@jlc/palm-mig/language-middleware --force-reinstall --no-deps
```
3. add the middleware in setting using the following config.
``` python
index_nelp_lang = index_nelp_lang = MIDDLEWARE.index("openedx.core.djangoapps.lang_pref.middleware.LanguagePreferenceMiddleware") + 1
MIDDLEWARE.insert(index_nelp_lang, "eox_nelp.middleware.PreserveUserLanguageCookieMiddleware")

```
[Screencast from 26-01-24 17:01:30.webm](https://github.com/eduNEXT/eox-nelp/assets/51926076/0db6895c-38a4-469f-9dd4-7a8937acea30)
### Before
[Screencast from 26-01-24 16:54:14.webm](https://github.com/eduNEXT/eox-nelp/assets/51926076/4feb48ca-8eb9-4b2b-9760-2a032652ee25)




### After
[Screencast from 26-01-24 17:02:47.webm](https://github.com/eduNEXT/eox-nelp/assets/51926076/1b1cacff-0bef-4ee1-b58d-0ad6f99c2421)
## Additional information

**PRS related**
original-pr with discussion: https://github.com/nelc/edx-platform/pull/5
migration pr: https://github.com/eduNEXT/edunext-platform/pull/672
## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
