### PR TITLE
And/add subsection processor

### DIFF
--- a/eox_nelp/apps.py
+++ b/eox_nelp/apps.py
@@ -77,6 +77,14 @@ class EoxNelpConfig(AppConfig):
                         'receiver_func_name': 'update_async_tracker_context',
                         'signal_path': 'celery.signals.task_prerun',
                     },
+                    {
+                        'receiver_func_name': 'emit_subsection_attempt_event',
+                        'signal_path': 'lms.djangoapps.grades.signals.signals.PROBLEM_WEIGHTED_SCORE_CHANGED',
+                    },
+                    {
+                        'receiver_func_name': 'emit_subsection_attempt_event',
+                        'signal_path': 'lms.djangoapps.grades.signals.signals.SUBSECTION_OVERRIDE_CHANGED',
+                    },
                 ],
             },
         },

--- a/eox_nelp/edxapp_wrapper/backends/event_routing_backends_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/event_routing_backends_m_v1.py
@@ -3,7 +3,7 @@
 This is required since the library has explicit dependencies from openedx platform.
 https://github.com/openedx/event-routing-backends
 """
-from event_routing_backends.processors.xapi import constants
+from event_routing_backends.processors.xapi import constants, event_transformers
 from event_routing_backends.processors.xapi.registry import XApiTransformersRegistry
 from event_routing_backends.processors.xapi.transformer import XApiTransformer
 
@@ -36,3 +36,13 @@ def get_xapi_transformer():
         XApiTransformer class.
     """
     return XApiTransformer
+
+
+def get_xapi_event_transformers():
+    """Allow to get the event_transformers module
+    https://github.com/openedx/event-routing-backends/blob/master/event_routing_backends/processors/xapi/event_transformers/__init__.py
+
+    Returns:
+        event_transformers module.
+    """
+    return event_transformers

--- a/eox_nelp/edxapp_wrapper/backends/grades_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/grades_m_v1.py
@@ -1,0 +1,14 @@
+"""Backend for lms grades djangoapp.
+This file contains all the necessary grades dependencies from
+https://github.com/eduNEXT/edunext-platform/tree/ednx-release/mango.master/lms/djangoapps/grade
+"""
+from lms.djangoapps.grades.subsection_grade_factory import SubsectionGradeFactory  # pylint: disable=import-error
+
+
+def get_subsection_grade_factory():
+    """Allow to get the SubsectionGradeFactory class from
+    https://github.com/eduNEXT/edunext-platform/blob/ednx-release/mango.master/lms/djangoapps/grades/subsection_grade_factory.py#L27
+    Returns:
+        SubsectionGradeFactory class.
+    """
+    return SubsectionGradeFactory

--- a/eox_nelp/edxapp_wrapper/event_routing_backends.py
+++ b/eox_nelp/edxapp_wrapper/event_routing_backends.py
@@ -6,6 +6,7 @@ Attributes:
     constants: Wrapper constants module.
     XApiTransformer: Wrapper for the XApiTransformer class.
     XApiTransformersRegistry: Wrapper for the XApiTransformersRegistry class.
+    event_transformers: Wrapper for general transformer events.
 """
 from importlib import import_module
 
@@ -14,5 +15,6 @@ from django.conf import settings
 backend = import_module(settings.EOX_NELP_EVENT_ROUTING_BACKEND)
 
 constants = backend.get_xapi_constants()
+event_transformers = backend.get_xapi_event_transformers()
 XApiTransformer = backend.get_xapi_transformer()
 XApiTransformersRegistry = backend.get_xapi_transformer_registry()

--- a/eox_nelp/edxapp_wrapper/grades.py
+++ b/eox_nelp/edxapp_wrapper/grades.py
@@ -1,0 +1,13 @@
+"""Wrapper grades djangoapp.
+This contains all the required dependencies from grades.
+Attributes:
+    backend:Imported module by using the plugin settings.
+    SubsectionGradeFactory: Wrapper for SubsectionGradeFactory class.
+"""
+from importlib import import_module
+
+from django.conf import settings
+
+backend = import_module(settings.EOX_NELP_GRADES_BACKEND)
+
+SubsectionGradeFactory = backend.get_subsection_grade_factory()

--- a/eox_nelp/edxapp_wrapper/test_backends/event_routing_backends_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/event_routing_backends_m_v1.py
@@ -19,6 +19,8 @@ def get_xapi_constants():
     constants.INITIALIZED = "initialized"
     constants.XAPI_ACTIVITY_MODULE = "http://adlnet.gov/expapi/activities/module"
     constants.XAPI_ACTIVITY_QUESTION = "http://adlnet.gov/expapi/activities/question"
+    constants.XAPI_VERB_ATTEMPTED = "http://adlnet.gov/expapi/verbs/attempted"
+    constants.ATTEMPTED = "attempted"
 
     return constants
 
@@ -56,4 +58,12 @@ def get_xapi_event_transformers():
     Returns:
         Mock class.
     """
-    return Mock()
+    class ProblemSubmittedTransformer:
+        pass
+
+    setattr(ProblemSubmittedTransformer, "get_data", Mock())
+    setattr(ProblemSubmittedTransformer, "get_object_iri", Mock())
+
+    return Mock(
+        ProblemSubmittedTransformer=ProblemSubmittedTransformer
+    )

--- a/eox_nelp/edxapp_wrapper/test_backends/event_routing_backends_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/event_routing_backends_m_v1.py
@@ -48,3 +48,12 @@ def get_xapi_transformer():
     setattr(XApiTransformer, "get_object_iri", Mock())
 
     return XApiTransformer
+
+
+def get_xapi_event_transformers():
+    """Test backend for the event_transformers module.
+
+    Returns:
+        Mock class.
+    """
+    return Mock()

--- a/eox_nelp/edxapp_wrapper/test_backends/grades_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/grades_m_v1.py
@@ -9,3 +9,12 @@ def get_course_grade_factory():
         Mock class.
     """
     return Mock()
+
+
+def get_subsection_grade_factory():
+    """Test backend for eox_nelp.edxapp_wrapper.backends.grades_m_v1.
+
+    Returns:
+        Mock class.
+    """
+    return Mock()

--- a/eox_nelp/openedx_filters/tests/xapi/tests_filters.py
+++ b/eox_nelp/openedx_filters/tests/xapi/tests_filters.py
@@ -3,7 +3,7 @@
 Classes:
     XApiActorFilterTestCase: Tests cases for XApiActorFilter filter class.
     XApiCourseObjectFilterTestCase: Test cases for XApiCourseObjectFilter filter class.
-    XApiModuleQuestionObjectFilterTestCase: Test cases for XApiModuleQuestionObjectFilter filter class.
+    XApiXblockObjectFilterTestCase: Test cases for XApiXblockObjectFilter filter class.
     XApiVerbFilterTestCase: Test cases for XApiVerbFilter filter class.
     XApiContextFilterTestCase: Test cases for XApiContextFilter filter class.
 """
@@ -22,8 +22,8 @@ from eox_nelp.openedx_filters.xapi.filters import (
     XApiActorFilter,
     XApiContextFilter,
     XApiCourseObjectFilter,
-    XApiModuleQuestionObjectFilter,
     XApiVerbFilter,
+    XApiXblockObjectFilter,
 )
 from eox_nelp.processors.xapi.constants import DEFAULT_LANGUAGE
 
@@ -194,8 +194,8 @@ class XApiCourseObjectFilterTestCase(TestCase):
 
 
 @ddt
-class XApiModuleQuestionObjectFilterTestCase(TestCase):
-    """Test class for XApiModuleQuestionObjectFilterr filter class."""
+class XApiXblockObjectFilterTestCase(TestCase):
+    """Test class for XApiXblockObjectFilterr filter class."""
 
     def setUp(self):
         """Setup common conditions for every test case"""
@@ -203,9 +203,9 @@ class XApiModuleQuestionObjectFilterTestCase(TestCase):
             "data.problem_id": "block-v1:edx+CS105+2023-T3+type@problem+block@0221040b086c4618b6b2b2a554558",
             "course_id": "course-v1:edx+CS105+2023-T3",
         }
-        self.filter = XApiModuleQuestionObjectFilter(
+        self.filter = XApiXblockObjectFilter(
             filter_type="event_routing_backends.processors.xapi.problem_interaction_events.base_problems.get_object",
-            running_pipeline=["eox_nelp.openedx_filters.xapi.filters.XApiModuleQuestionObjectFilter"],
+            running_pipeline=["eox_nelp.openedx_filters.xapi.filters.XApiXblockObjectFilter"],
         )
         self.transformer = Mock()
         self.transformer.event = {"name": "edx.grades.problem.submitted"}

--- a/eox_nelp/processors/tests/xapi/event_transformers/tests_grade_events.py
+++ b/eox_nelp/processors/tests/xapi/event_transformers/tests_grade_events.py
@@ -1,0 +1,86 @@
+"""This file contains all the test for the grade_events.py file.
+
+Classes:
+    SubsectionSubmittedTransformerTestCase: Tests cases for SubsectionSubmittedTransformer class.
+"""
+from django.test import TestCase
+from tincan import ActivityDefinition, LanguageMap, Result
+
+from eox_nelp.edxapp_wrapper.event_routing_backends import constants
+from eox_nelp.processors.xapi import constants as eox_nelp_constants
+from eox_nelp.processors.xapi.event_transformers import SubsectionSubmittedTransformer
+
+
+class SubsectionSubmittedTransformerTestCase(TestCase):
+    """Test class for SubsectionSubmittedTransformer class."""
+
+    def setUp(self):
+        """Setup common conditions for every test case"""
+        self.default_values = {
+            "data.block_id": "block-v1:test+CS501+2022_T4+type@sequential+block@a54730a9b89f420a8d0343dd581b447a",
+            "data.earned": 15,
+            "data.possible": 30,
+            "data.percent": 50,
+        }
+        self.transformer = SubsectionSubmittedTransformer()
+        self.transformer.get_data.side_effect = lambda x: self.default_values[x]
+
+    def tearDown(self):
+        """Restore mocks' state"""
+        self.transformer.get_data.reset_mock()
+
+    def test_verb_attribute(self):
+        """ Test case that checks that the get_verb method returns right values.
+
+        Expected behavior:
+            - Verb id is the expected value.
+            - Verb display is the expected value.
+        """
+        verb = self.transformer.get_verb()
+
+        self.assertEqual(constants.XAPI_VERB_ATTEMPTED, verb.id)
+        self.assertEqual(LanguageMap({eox_nelp_constants.DEFAULT_LANGUAGE: constants.ATTEMPTED}), verb.display)
+
+    def test_get_object_id(self):
+        """ Test case that checks that the get_object_id method returns the right value.
+
+        Expected behavior:
+            - result is the expected value.
+        """
+        result = self.transformer.get_object_id()
+
+        self.assertEqual(self.default_values["data.block_id"], result)
+
+    def test_get_object_definition(self):
+        """ Test case that checks that the get_object_definition method returns the right value.
+
+        Expected behavior:
+            - result is the expected value.
+        """
+        expected_value = ActivityDefinition(
+            type=eox_nelp_constants.XAPI_ACTIVITY_UNIT_TEST
+        )
+
+        result = self.transformer.get_object_definition()
+
+        self.assertEqual(expected_value, result)
+
+    def test_get_result(self):
+        """ Test case that checks that the get_result method returns the right value.
+
+        Expected behavior:
+            - result is the expected value.
+        """
+        expected_value = Result(
+            success=self.default_values["data.earned"] >= self.default_values["data.possible"],
+            score={
+                "min": 0,
+                "max": self.default_values["data.possible"],
+                "raw": self.default_values["data.earned"],
+                "scaled": self.default_values["data.percent"],
+            }
+        )
+
+        result = self.transformer.get_result()
+
+        self.assertEqual(expected_value, result)

--- a/eox_nelp/processors/xapi/constants.py
+++ b/eox_nelp/processors/xapi/constants.py
@@ -9,4 +9,6 @@ MAX_FEEDBACK_SCORE = RATING_OPTIONS[-1][0]
 MIN_FEEDBACK_SCORE = 0
 
 XAPI_ACTIVITY_COURSE = "https://w3id.org/xapi/cmi5/activitytype/course"
+XAPI_ACTIVITY_UNIT_TEST = "http://id.tincanapi.com/activitytype/unit-test"
+
 XAPI_VERB_RATED = "http://id.tincanapi.com/verb/rated"

--- a/eox_nelp/processors/xapi/event_transformers/__init__.py
+++ b/eox_nelp/processors/xapi/event_transformers/__init__.py
@@ -5,4 +5,5 @@ from eox_nelp.processors.xapi.event_transformers.course_experience_events import
     FeedBackCourseTransformer,
     FeedBackUnitTransformer,
 )
+from eox_nelp.processors.xapi.event_transformers.grade_events import SubsectionSubmittedTransformer  # noqa: F401
 from eox_nelp.processors.xapi.event_transformers.initialized_events import InitializedCourseTransformer  # noqa: F401

--- a/eox_nelp/processors/xapi/event_transformers/grade_events.py
+++ b/eox_nelp/processors/xapi/event_transformers/grade_events.py
@@ -1,0 +1,69 @@
+"""
+Transformers for grading events.
+
+Classes:
+    SubsectionSubmittedTransformer: Transformer for the event nelc.eox_nelp.grades.subsection.submitted.
+"""
+from tincan import ActivityDefinition, LanguageMap, Result, Verb
+
+from eox_nelp.edxapp_wrapper.event_routing_backends import XApiTransformersRegistry, constants, event_transformers
+from eox_nelp.processors.xapi import constants as eox_nelp_constants
+
+
+@XApiTransformersRegistry.register("nelc.eox_nelp.grades.subsection.submitted")
+class SubsectionSubmittedTransformer(event_transformers.ProblemSubmittedTransformer):
+    """Transformer class for the event nelc.eox_nelp.grades.subsection.submitted."""
+
+    additional_fields = ('result', )
+
+    def get_verb(self):
+        """
+        Get verb for xAPI transformed event.
+
+        Returns:
+            `Verb`
+        """
+        return Verb(
+            id=constants.XAPI_VERB_ATTEMPTED,
+            display=LanguageMap({eox_nelp_constants.DEFAULT_LANGUAGE: constants.ATTEMPTED}),
+        )
+
+    def get_object_id(self):
+        """
+        Returns the object id.
+
+        Returns:
+            <str>: string representation of the block id.
+        """
+        return self.get_data("data.block_id")
+
+    def get_object_definition(self):
+        """
+        Returns the object definition.
+
+        Returns:
+            ActivityDefinition
+        """
+        return ActivityDefinition(
+            type=eox_nelp_constants.XAPI_ACTIVITY_UNIT_TEST
+        )
+
+    def get_result(self):
+        """
+        Get result for xAPI transformed event.
+
+        Returns:
+            `Result`
+        """
+        earned = self.get_data("data.earned") or 0
+        possible = self.get_data("data.possible") or 0
+
+        return Result(
+            success=earned >= possible,
+            score={
+                "min": 0,
+                "max": possible,
+                "raw": earned,
+                "scaled": self.get_data("data.percent") or 0,
+            }
+        )

--- a/eox_nelp/settings/common.py
+++ b/eox_nelp/settings/common.py
@@ -48,6 +48,7 @@ def plugin_settings(settings):
     settings.EOX_NELP_CERTIFICATES_BACKEND = 'eox_nelp.edxapp_wrapper.backends.certificates_m_v1'
     settings.EOX_NELP_CMS_API_BACKEND = 'eox_nelp.edxapp_wrapper.backends.cms_api_m_v1'
     settings.EOX_NELP_EVENT_ROUTING_BACKEND = 'eox_nelp.edxapp_wrapper.backends.event_routing_backends_m_v1'
+    settings.EOX_NELP_GRADES_BACKEND = 'eox_nelp.edxapp_wrapper.backends.grades_m_v1'
 
     settings.FUTUREX_API_URL = 'https://testing-site.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -34,6 +34,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.EOX_NELP_CERTIFICATES_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.certificates_m_v1'
     settings.EOX_NELP_CMS_API_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.cms_api_m_v1'
     settings.EOX_NELP_EVENT_ROUTING_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.event_routing_backends_m_v1'
+    settings.EOX_NELP_GRADES_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.grades_m_v1'
 
     settings.FUTUREX_API_URL = 'https://testing.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'

--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -294,8 +294,8 @@ def emit_subsection_attempt_event(usage_id, user_id, *args, **kwargs):  # pylint
             {
                 "user_id": user_id,
                 "course_id": str(usage_key.context_key),
-                "block_id": str(subsection.location),
-                "submitted_at": timezone.now(),
+                "block_id": str(subsection_grade.location),
+                "submitted_at": timezone.now().strftime("%Y-%m-%d, %H:%M:%S"),
                 "earned": subsection_grade.graded_total.earned,
                 "possible": subsection_grade.graded_total.possible,
                 "percent": subsection_grade.percent_graded,

--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -9,19 +9,26 @@ Functions:
     certificate_publisher: Publish the user certificate data to the NELC certificates service.
     include_tracker_context: Append tracker context to async task data.
     update_async_tracker_context: Update tracker context based on the task data.
+    emit_subsection_attempt_event: Emits an event when a graded subsection has been attempted.
 """
 import logging
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.utils import timezone
 from eox_core.edxapp_wrapper.grades import get_course_grade_factory
 from eventtracking import tracker
+from opaque_keys.edx.keys import UsageKey
 from openedx_events.learning.data import CertificateData, CourseData, UserData, UserPersonalData
 
+from eox_nelp.edxapp_wrapper.grades import SubsectionGradeFactory
+from eox_nelp.edxapp_wrapper.modulestore import modulestore
 from eox_nelp.notifications.tasks import create_course_notifications as create_course_notifications_task
 from eox_nelp.payment_notifications.models import PaymentNotification
 from eox_nelp.signals.tasks import create_external_certificate, dispatch_futurex_progress
 from eox_nelp.signals.utils import _generate_external_certificate_data
 
+User = get_user_model()
 LOGGER = logging.getLogger(__name__)
 CourseGradeFactory = get_course_grade_factory()
 
@@ -266,3 +273,31 @@ def update_async_tracker_context(sender, *args, **kwargs):  # pylint: disable=un
     tracker_context = request.get("kwargs", {}).pop("tracker_context", {})
     current_tracker = tracker.get_tracker()
     current_tracker.enter_context("asynchronous_context", tracker_context)
+
+
+def emit_subsection_attempt_event(usage_id, user_id, *args, **kwargs):  # pylint: disable=unused-argument
+    """This emits  the 'nelc.eox_nelp.grades.subsection.submitted' event
+    when a graded subsection has been attempted.
+    """
+    store = modulestore()
+    user = User.objects.get(id=user_id)
+    usage_key = UsageKey.from_string(usage_id)
+    vertical = store.get_item(store.get_parent_location(usage_key))
+    subsection = vertical.get_parent()
+    course = store.get_course(usage_key.course_key)
+    subsection_grade_factory = SubsectionGradeFactory(user, course=course)
+    subsection_grade = subsection_grade_factory.create(subsection=subsection, read_only=True, force_calculate=True)
+
+    if subsection_grade.graded:
+        tracker.emit(
+            "nelc.eox_nelp.grades.subsection.submitted",
+            {
+                "user_id": user_id,
+                "course_id": str(usage_key.context_key),
+                "block_id": str(subsection.location),
+                "submitted_at": timezone.now(),
+                "earned": subsection_grade.graded_total.earned,
+                "possible": subsection_grade.graded_total.possible,
+                "percent": subsection_grade.percent_graded,
+            }
+        )


### PR DESCRIPTION

## Description

This pr includes two things
1. This emit a new event called `nelc.eox_nelp.grades.subsection.submitted`
2.  Includes a new transformer for the added event 

## Testing instructions
1. add the event to the XAPI settings 
```
EVENT_TRACKING_BACKENDS["xapi"] = {
    "ENGINE": "eventtracking.backends.async_routing.AsyncRoutingBackend",
    "OPTIONS": {
        "backend_name": "xapi",
        "processors": [
            {
                "ENGINE": "eventtracking.processors.whitelist.NameWhitelistProcessor",
                "OPTIONS": {
                    "whitelist": [
                        "nelc.eox_nelp.grades.subsection.submitted",
                    ]
                }
            }
        ],
        "backends": {
            "xapi": {
                "ENGINE": "event_routing_backends.backends.events_router.EventsRouter",
                "OPTIONS": {
                    "processors": [
                        {
                            "ENGINE": "event_routing_backends.processors.xapi.transformer_processor.XApiProcessor",
                            "OPTIONS": {}
                        }
                    ],
                    "backend_name": "xapi"
                }
            }
        }
    }
}
```
2. Go to a unit inside a graded subsection, a  graded subsection is the one what was configure with the grade as parameter in studio 
3. Complete any problem 
4. check the transformer result

e.g Aspects 

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/767fb668-77d6-412c-b6be-af38426e0a0e)

