### PR TITLE
chore: this remove the eox nelp XAPI_ACTIVITY_COURSE CONSTANT in favo…

### DIFF
--- a/eox_nelp/processors/tests/xapi/mixins.py
+++ b/eox_nelp/processors/tests/xapi/mixins.py
@@ -68,7 +68,7 @@ class BaseCourseObjectTestCaseMixin:
         self.assertEqual(object_id, activity.id)
         self.assertEqual(
             ActivityDefinition(
-                type=eox_nelp_constants.XAPI_ACTIVITY_COURSE,
+                type=constants.XAPI_ACTIVITY_COURSE,
                 name=LanguageMap({course["language"]: course["display_name"]}),
                 description=LanguageMap({course["language"]: course["short_description"]}),
             ),
@@ -98,7 +98,7 @@ class BaseCourseObjectTestCaseMixin:
 
         self.assertEqual(
             ActivityDefinition(
-                type=eox_nelp_constants.XAPI_ACTIVITY_COURSE,
+                type=constants.XAPI_ACTIVITY_COURSE,
                 name=LanguageMap({eox_nelp_constants.DEFAULT_LANGUAGE: course["display_name"]}),
                 description=LanguageMap({eox_nelp_constants.DEFAULT_LANGUAGE: course["short_description"]}),
             ),

--- a/eox_nelp/processors/xapi/constants.py
+++ b/eox_nelp/processors/xapi/constants.py
@@ -8,7 +8,6 @@ RATED = "rated"
 MAX_FEEDBACK_SCORE = RATING_OPTIONS[-1][0]
 MIN_FEEDBACK_SCORE = 0
 
-XAPI_ACTIVITY_COURSE = "https://w3id.org/xapi/cmi5/activitytype/course"
 XAPI_ACTIVITY_UNIT_TEST = "http://id.tincanapi.com/activitytype/unit-test"
 
 XAPI_VERB_RATED = "http://id.tincanapi.com/verb/rated"

--- a/eox_nelp/processors/xapi/mixins.py
+++ b/eox_nelp/processors/xapi/mixins.py
@@ -46,7 +46,7 @@ class BaseCourseObjectTransformerMixin:
         return Activity(
             id=self.get_object_iri("courses", self.course_id),
             definition=ActivityDefinition(
-                type=eox_nelp_constants.XAPI_ACTIVITY_COURSE,
+                type=constants.XAPI_ACTIVITY_COURSE,
                 name=LanguageMap(**({course_language: display_name} if display_name is not None else {})),
                 description=LanguageMap(**({course_language: description} if description is not None else {})),
             ),


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->
## Description

This remove the eox nelp XAPI_ACTIVITY_COURSE CONSTANT in favor of event-routing-backends constant

## Testing instructions
1. This affects two events `initialized course ` and `rated course,` you can follow these [instructions ](https://github.com/eduNEXT/eox-nelp/pull/112)  or[ this ](https://github.com/eduNEXT/eox-nelp/pull/115)
2. Check the object type  for the generated statement 

### Before
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/ab94e5b4-ceb9-444e-8c08-bc67265353c7)

### After

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/6603b192-c5e3-4300-a052-29cd1000645a)


## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
