### PR TITLE
feat: include attempts in subsection attempt event

### DIFF
--- a/eox_nelp/edxapp_wrapper/backends/course_blocks_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/course_blocks_m_v1.py
@@ -1,0 +1,13 @@
+"""Backend for course_blocks django app module.
+This file contains all the necessary course_blocks dependencies from
+https://github.com/eduNEXT/edunext-platform/blob/ednx-release/mango.master/lms/djangoapps/course_blocks/__init__.py"""
+from lms.djangoapps.course_blocks.utils import get_student_module_as_dict
+
+
+def get_student_module_as_dict_method():
+    """Allow to get the get_visible_courses function from
+    https://github.com/eduNEXT/edunext-platform/blob/ednx-release/mango.master/lms/djangoapps/course_blocks/__init__.py#L17
+    Returns:
+        get_visible_courses function.
+    """
+    return get_student_module_as_dict

--- a/eox_nelp/edxapp_wrapper/course_blocks.py
+++ b/eox_nelp/edxapp_wrapper/course_blocks.py
@@ -1,0 +1,12 @@
+"""Wrapper for module in course_blocks app.
+This contains all the required dependencies from course_blocks.
+Attributes:
+    get_student_module_as_dict: Wrapper get_student_module_as_dict function.
+"""
+from importlib import import_module
+
+from django.conf import settings
+
+backend = import_module(settings.EOX_NELP_COURSE_BLOCKS_BACKEND)
+
+get_student_module_as_dict = backend.get_student_module_as_dict_method()

--- a/eox_nelp/edxapp_wrapper/test_backends/course_blocks_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/course_blocks_m_v1.py
@@ -1,0 +1,10 @@
+"""Test backend for course_blocks module."""
+from mock import Mock
+
+
+def get_student_module_as_dict_method():
+    """Return test function.
+    Returns:
+        Mock class.
+    """
+    return Mock()

--- a/eox_nelp/settings/common.py
+++ b/eox_nelp/settings/common.py
@@ -49,6 +49,7 @@ def plugin_settings(settings):
     settings.EOX_NELP_CMS_API_BACKEND = 'eox_nelp.edxapp_wrapper.backends.cms_api_m_v1'
     settings.EOX_NELP_EVENT_ROUTING_BACKEND = 'eox_nelp.edxapp_wrapper.backends.event_routing_backends_m_v1'
     settings.EOX_NELP_GRADES_BACKEND = 'eox_nelp.edxapp_wrapper.backends.grades_m_v1'
+    settings.EOX_NELP_COURSE_BLOCKS_BACKEND = 'eox_nelp.edxapp_wrapper.backends.course_blocks_m_v1'
 
     settings.FUTUREX_API_URL = 'https://testing-site.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -35,6 +35,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.EOX_NELP_CMS_API_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.cms_api_m_v1'
     settings.EOX_NELP_EVENT_ROUTING_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.event_routing_backends_m_v1'
     settings.EOX_NELP_GRADES_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.grades_m_v1'
+    settings.EOX_NELP_COURSE_BLOCKS_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.course_blocks_m_v1'
 
     settings.FUTUREX_API_URL = 'https://testing.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -13,12 +13,10 @@ from django.test import override_settings
 from django.utils import timezone
 from eventtracking.tracker import get_tracker
 from mock import Mock, patch
-from opaque_keys.edx.keys import CourseKey, UsageKey
+from opaque_keys.edx.keys import CourseKey
 from openedx_events.data import EventsMetadata
 from openedx_events.learning.data import CertificateData, CourseData, UserData, UserPersonalData
 
-from eox_nelp.edxapp_wrapper.grades import SubsectionGradeFactory
-from eox_nelp.edxapp_wrapper.modulestore import modulestore
 from eox_nelp.edxapp_wrapper.test_backends import create_test_model
 from eox_nelp.signals import receivers
 from eox_nelp.signals.receivers import (
@@ -550,108 +548,19 @@ class UpdateAsyncTrackerContextTestCase(unittest.TestCase):
 class EmitSubsectionAttemptEventTestCase(unittest.TestCase):
     """Test class for emit_subsection_attempt_event method."""
 
-    def setUp(self):
-        """Setup common conditions for every test case"""
-        self.usage_key = UsageKey.from_string(
-            "block-v1:edx+CS105+2023-T3+type@problem+block@0221040b086c4618b6b2b2a554558",
-        )
-        self.user, _ = User.objects.get_or_create(username="Petunia")
-
-    def tearDown(self):
-        """Restore mocks' state"""
-        modulestore.reset_mock()
-        SubsectionGradeFactory.reset_mock()
-
-    def mock_validations(self):
-        """This method contains general mock validations for the emit_subsection_attempt_event method."""
-        # 1. modulestore was called once.
-        modulestore.assert_called_once()
-
-        store = modulestore()
-
-        # 2. get_parent_location was once with the usage key
-        get_parent_location = store.get_parent_location
-        get_parent_location.assert_called_once_with(self.usage_key)
-
-        parent_location = get_parent_location()
-
-        # 3. get_item was once with the result of get_parent_location.
-        get_item = store.get_item
-        get_item.assert_called_once_with(parent_location)
-
-        # 4. get_parent was called once.
-        vertical = get_item()
-        vertical.get_parent.assert_called_once()
-
-        subsection = vertical.get_parent()
-
-        # 5. get_course was once with the course key.
-        get_course = store.get_course
-        get_course.assert_called_once_with(self.usage_key.course_key)
-
-        course = get_course()
-
-        # 6. SubsectionGradeFactory was called once with the user instance and the result of get_course method.
-        SubsectionGradeFactory.assert_called_once_with(self.user, course=course)
-
-        subsection_grade_factory = SubsectionGradeFactory()
-
-        # 7. subsection_grade_factory create method was called once with the result of vertical.get_parent(),
-        # read_only equal to True and force_calculate equal to True.
-        subsection_grade_factory.create.assert_called_once_with(
-            subsection=subsection,
-            read_only=True,
-            force_calculate=True,
-        )
-
-    @patch("eox_nelp.signals.receivers.tracker")
-    def test_event_is_not_emitted(self, tracker_mock):
-        """
-        This tests when the subsection is not graded
-        therefore the event is not emitted.
+    @patch("eox_nelp.signals.receivers.emit_subsection_attempt_event_task")
+    def test_call_async_task(self, task_mock):
+        """Test that the async task is called with the right parameters
 
         Expected behavior:
-            - tracking.emit method is not called.
-            - mock validations passes.
+            - delay method is called with the right values.
         """
-        subsection_grade = Mock(graded=False)
-        SubsectionGradeFactory.return_value.create.return_value = subsection_grade
+        usage_id = ""
+        user_id = 5
 
-        emit_subsection_attempt_event(str(self.usage_key), self.user.id)
+        emit_subsection_attempt_event(usage_id, user_id)
 
-        tracker_mock.emit.assert_not_called()
-        self.mock_validations()
-
-    @patch("eox_nelp.signals.receivers.tracker")
-    def test_event_is_emitted(self, tracker_mock):
-        """
-        This tests when the subsection is gradable and the event is emitted
-
-        Expected behavior:
-            - tracking.emit method is called with the right values.
-            - mock validations passes.
-        """
-        graded_total = Mock(earned=15, possible=30)
-        subsection_grade = Mock(
-            graded=True,
-            percent_graded=50,
-            graded_total=graded_total,
-            location="block-v1:test+CS501+2022_T4+type@sequential+block@a54730a9b89f420a8d0343dd581b447a",
+        task_mock.delay.assert_called_with(
+            usage_id=usage_id,
+            user_id=user_id,
         )
-        SubsectionGradeFactory.return_value.create.return_value = subsection_grade
-
-        emit_subsection_attempt_event(str(self.usage_key), self.user.id)
-
-        tracker_mock.emit.assert_called_once_with(
-            "nelc.eox_nelp.grades.subsection.submitted",
-            {
-                "user_id": self.user.id,
-                "course_id": str(self.usage_key.context_key),
-                "block_id": str(subsection_grade.location),
-                "submitted_at": timezone.now().strftime("%Y-%m-%d, %H:%M:%S"),
-                "earned": graded_total.earned,
-                "possible": graded_total.possible,
-                "percent": subsection_grade.percent_graded,
-            }
-        )
-        self.mock_validations()


### PR DESCRIPTION
## Description
This includes the attempt's number in the subsection attempt event and small refactor

the refactor basically moves the logic from the receiver method to an async task, since to calculate the attempt's number requires iterate over all the subsection components

## Testing instructions
1. Go to a unit inside a graded subsection, a graded subsection is the one what was configure with the grade as parameter in studio
2. Check the logs

Expected result
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/9ff35ce3-3e8c-4501-bd50-782766714a1c)


## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
