### PR TITLE
feat: this overrides the get_context method to include the attempt ex…

### DIFF
--- a/eox_nelp/edxapp_wrapper/test_backends/event_routing_backends_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/event_routing_backends_m_v1.py
@@ -21,6 +21,7 @@ def get_xapi_constants():
     constants.XAPI_ACTIVITY_QUESTION = "http://adlnet.gov/expapi/activities/question"
     constants.XAPI_VERB_ATTEMPTED = "http://adlnet.gov/expapi/verbs/attempted"
     constants.ATTEMPTED = "attempted"
+    constants.XAPI_ACTIVITY_ATTEMPT = "http://id.tincanapi.com/extension/attempt-id"
 
     return constants
 
@@ -63,6 +64,7 @@ def get_xapi_event_transformers():
 
     setattr(ProblemSubmittedTransformer, "get_data", Mock())
     setattr(ProblemSubmittedTransformer, "get_object_iri", Mock())
+    setattr(ProblemSubmittedTransformer, "get_context", Mock())
 
     return Mock(
         ProblemSubmittedTransformer=ProblemSubmittedTransformer

--- a/eox_nelp/processors/xapi/event_transformers/grade_events.py
+++ b/eox_nelp/processors/xapi/event_transformers/grade_events.py
@@ -4,7 +4,7 @@ Transformers for grading events.
 Classes:
     SubsectionSubmittedTransformer: Transformer for the event nelc.eox_nelp.grades.subsection.submitted.
 """
-from tincan import ActivityDefinition, LanguageMap, Result, Verb
+from tincan import ActivityDefinition, Extensions, LanguageMap, Result, Verb
 
 from eox_nelp.edxapp_wrapper.event_routing_backends import XApiTransformersRegistry, constants, event_transformers
 from eox_nelp.processors.xapi import constants as eox_nelp_constants
@@ -67,3 +67,22 @@ class SubsectionSubmittedTransformer(event_transformers.ProblemSubmittedTransfor
                 "scaled": self.get_data("data.percent") or 0,
             }
         )
+
+    def get_context(self):
+        """
+        Get context for xAPI transformed event.
+        Returns:
+            `Context`
+        """
+        context = super().get_context()
+
+        attempts_extension = {
+            constants.XAPI_ACTIVITY_ATTEMPT: self.get_data("data.attempts")
+        }
+
+        if context.extensions:
+            context.extensions.update(attempts_extension)
+        else:
+            context.extensions = Extensions(attempts_extension)
+
+        return context


### PR DESCRIPTION
## Description
this overrides the get_context method to include the attempt extension

## Testing instructions
1. Folow the instructions of this [pr ](https://github.com/eduNEXT/eox-nelp/pull/128)
2. Check that the extension has been added

##### Expected result

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/9e0e7452-6c09-4954-8c72-9cfa88dfdd19)

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
