### PR TITLE
And/add mt integration

### DIFF
--- a/eox_nelp/api_clients/__init__.py
+++ b/eox_nelp/api_clients/__init__.py
@@ -124,17 +124,6 @@ class AbstractOauth2ApiClient(AbstractApiClient):
         client_secret (str): Client secret for OAuth 2.0 authentication.
     """
 
-    def __init__(self):
-        """Initialize an instance of AbstractOauth2ApiClient.
-
-        Gets the client ID and client secret from Django settings and then
-        calls the constructor of the parent class (AbstractApiClient).
-        """
-        self.client_id = getattr(settings, "FUTUREX_API_CLIENT_ID")
-        self.client_secret = getattr(settings, "FUTUREX_API_CLIENT_SECRET")
-
-        super().__init__()
-
     def _authenticate(self):
         """Authenticate the session with OAuth 2.0 credentials.
 
@@ -147,6 +136,7 @@ class AbstractOauth2ApiClient(AbstractApiClient):
         Returns:
             requests.Session: Session authenticated with OAuth 2.0 credentials.
         """
+        # pylint: disable=no-member
         key = f"{self.client_id}-{self.client_secret}"
         headers = cache.get(key)
 
@@ -182,17 +172,6 @@ class AbstractBasicAuthApiClient(AbstractApiClient):
         password (str): Password for basic authentication.
     """
 
-    def __init__(self):
-        """Initialize an instance of AbstractBasicAuthApiClient.
-
-        Gets the user and password from Django settings and then calls
-        the constructor of the parent class (AbstractApiClient).
-        """
-        self.user = getattr(settings, "EXTERNAL_CERTIFICATES_USER")
-        self.password = getattr(settings, "EXTERNAL_CERTIFICATES_PASSWORD")
-
-        super().__init__()
-
     def _authenticate(self):
         """Authenticate the session with the user and password.
 
@@ -202,6 +181,7 @@ class AbstractBasicAuthApiClient(AbstractApiClient):
         Returns:
             requests.Session: Session authenticated.
         """
+        # pylint: disable=no-member
         session = requests.Session()
         session.auth = HTTPBasicAuth(self.user, self.password)
 

--- a/eox_nelp/api_clients/futurex.py
+++ b/eox_nelp/api_clients/futurex.py
@@ -16,6 +16,13 @@ class FuturexApiClient(AbstractOauth2ApiClient):
         base_url: Futurex domain.
         session: persist certain parameters across requests.
     """
+
+    def __init__(self):
+        self.client_id = getattr(settings, "FUTUREX_API_CLIENT_ID")
+        self.client_secret = getattr(settings, "FUTUREX_API_CLIENT_SECRET")
+
+        super().__init__()
+
     @property
     def base_url(self):
         return getattr(settings, "FUTUREX_API_URL")

--- a/eox_nelp/api_clients/mt.py
+++ b/eox_nelp/api_clients/mt.py
@@ -1,0 +1,55 @@
+"""Client module for minister of tourism API integration.
+
+Classes:
+    MinisterOfTourismApiClient: Class to interact with Minister of tourism external service.
+"""
+from django.conf import settings
+
+from eox_nelp.api_clients import AbstractBasicAuthApiClient
+
+try:
+    from eox_audit_model.decorators import audit_method
+except ImportError:
+    def audit_method(action):  # pylint: disable=unused-argument
+        """Identity audit_method"""
+        return lambda x: x
+
+
+class MinisterOfTourismApiClient(AbstractBasicAuthApiClient):
+    """Allow to perform multiple external certificates operations."""
+
+    def __init__(self):
+        self.user = getattr(settings, "MINISTER_OF_TOURISM_USER")
+        self.password = getattr(settings, "MINISTER_OF_TOURISM_PASSWORD")
+
+        super().__init__()
+
+    @property
+    def base_url(self):
+        return getattr(settings, "MINISTER_OF_TOURISM_API_URL")
+
+    def update_training_stage(self, course_id, national_id, stage_result):
+        """This updates the training stage, changes the status to pass or fail, and stores them in HCD
+        database. If the training stage is already updated or some parameters are missing or wrong, an error
+        message is returned.
+
+        Arguments:
+            course_id<str>: Course identifier as string, e.g, course-v1:edx+cos104+T4_2023
+            national_id<str>: User national identifier, e.g. 1087583085
+            stage_result<int>: Representation of pass or fail result, 1 for pass 2 for fail.
+
+        Returns:
+            response<Dict>: requests response as dictionary.
+        """
+        @audit_method(action="Publish MT course completion stage")
+        def update_training_stage_request(course_id, national_id, stage_result):
+            """This is a wrapper that allows to make audit-able the update_training_stage method."""
+            path = "api/v2/LMSCourse/UpdateTrainingStage"
+            payload = {
+                "courseLMSId": course_id,
+                "userNationalId": national_id,
+                "applicationStageResult": stage_result,
+            }
+            return self.make_post(path, payload)
+
+        return update_training_stage_request(course_id, national_id, stage_result)

--- a/eox_nelp/api_clients/tests/__init__.py
+++ b/eox_nelp/api_clients/tests/__init__.py
@@ -213,10 +213,7 @@ class TestBasicAuthApiClientMixin(TestApiClientMixin):
             - api client has the attribute session
             - Session has the right auth value.
         """
-        expected_auth = HTTPBasicAuth(
-            settings.EXTERNAL_CERTIFICATES_USER,
-            settings.EXTERNAL_CERTIFICATES_PASSWORD
-        )
+        expected_auth = HTTPBasicAuth(self.user, self.password)
         session_mock.return_value.auth = expected_auth
 
         api_client = self.api_class()

--- a/eox_nelp/api_clients/tests/test_mt.py
+++ b/eox_nelp/api_clients/tests/test_mt.py
@@ -1,0 +1,55 @@
+"""This file contains all the test for mt api client file.
+
+Classes:
+    TestMinisterOfTourismApiClient: Test for eox-nelp/api_clients/mt.py.
+"""
+import unittest
+
+from django.conf import settings
+from mock import Mock, patch
+
+from eox_nelp.api_clients.mt import MinisterOfTourismApiClient
+from eox_nelp.api_clients.tests import TestBasicAuthApiClientMixin
+
+
+class TestMinisterOfTourismApiClient(TestBasicAuthApiClientMixin, unittest.TestCase):
+    """Tests MinisterOfTourismApiClient"""
+
+    def setUp(self):
+        """Setup common conditions for every test case"""
+        self.api_class = MinisterOfTourismApiClient
+        self.user = settings.MINISTER_OF_TOURISM_USER
+        self.password = settings.MINISTER_OF_TOURISM_PASSWORD
+
+    @patch.object(MinisterOfTourismApiClient, "make_post")
+    @patch.object(MinisterOfTourismApiClient, "_authenticate", Mock)
+    def test_create_certificate(self, post_mock):
+        """Test successful post request.
+
+        Expected behavior:
+            - Response is the expected value
+        """
+        expected_value = {
+            "correlationID": "f3e013f8-a9e4-4714-8162-4e3384f81578",
+            "responseCode": 100,
+            "responseMessage": "The update has been successfully",
+            "data": {
+                "result": True
+            },
+            "elaspsedTime": 0.2972466
+        }
+        post_mock.return_value = expected_value
+        course_id = "course-v1:FutureX+guide+2023"
+        national_id = "1222555888"
+        stage_result = 1
+        api_client = self.api_class()
+
+        response = api_client.update_training_stage(
+            course_id=course_id,
+            national_id=national_id,
+            stage_result=stage_result,
+        )
+
+        self.assertDictEqual(response, expected_value)
+
+        self.assertDictEqual(response, expected_value)

--- a/eox_nelp/api_clients/tests/test_mt.py
+++ b/eox_nelp/api_clients/tests/test_mt.py
@@ -36,7 +36,7 @@ class TestMinisterOfTourismApiClient(TestBasicAuthApiClientMixin, unittest.TestC
             "data": {
                 "result": True
             },
-            "elaspsedTime": 0.2972466
+            "elapsedTime": 0.2972466
         }
         post_mock.return_value = expected_value
         course_id = "course-v1:FutureX+guide+2023"

--- a/eox_nelp/api_clients/tests/tests_certificates.py
+++ b/eox_nelp/api_clients/tests/tests_certificates.py
@@ -5,6 +5,7 @@ Classes:
 """
 import unittest
 
+from django.conf import settings
 from django.test import override_settings
 from django.utils import timezone
 from mock import Mock, patch
@@ -20,6 +21,8 @@ class TestExternalCertificatesApiClient(TestBasicAuthApiClientMixin, unittest.Te
     def setUp(self):
         """Setup common conditions for every test case"""
         self.api_class = ExternalCertificatesApiClient
+        self.user = settings.EXTERNAL_CERTIFICATES_USER
+        self.password = settings.EXTERNAL_CERTIFICATES_PASSWORD
 
     @patch.object(ExternalCertificatesApiClient, "make_post")
     @patch.object(ExternalCertificatesApiClient, "_authenticate", Mock)

--- a/eox_nelp/apps.py
+++ b/eox_nelp/apps.py
@@ -85,6 +85,22 @@ class EoxNelpConfig(AppConfig):
                         'receiver_func_name': 'emit_subsection_attempt_event',
                         'signal_path': 'lms.djangoapps.grades.signals.signals.SUBSECTION_OVERRIDE_CHANGED',
                     },
+                    {
+                        'receiver_func_name': 'mt_course_completion_handler',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'dispatch_uid': 'mt_course_completion_receviver',
+                        'sender_path': 'completion.models.BlockCompletion',
+                    },
+                    {
+                        'receiver_func_name': 'mt_course_passed_handler',
+                        'signal_path': 'openedx.core.djangoapps.signals.signals.COURSE_GRADE_NOW_PASSED',
+                        'dispatch_uid': 'mt_course_passed_receiver',
+                    },
+                    {
+                        'receiver_func_name': 'mt_course_failed_handler',
+                        'signal_path': 'openedx.core.djangoapps.signals.signals.COURSE_GRADE_NOW_FAILED',
+                        'dispatch_uid': 'mt_course_failed_receiver',
+                    },
                 ],
             },
         },

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -46,6 +46,9 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.EXTERNAL_CERTIFICATES_API_URL = 'https://testing.com'
     settings.EXTERNAL_CERTIFICATES_USER = 'test-user'
     settings.EXTERNAL_CERTIFICATES_PASSWORD = 'test-password'
+    settings.MINISTER_OF_TOURISM_API_URL = 'https://testing.com'
+    settings.MINISTER_OF_TOURISM_USER = 'test-user'
+    settings.MINISTER_OF_TOURISM_PASSWORD = 'test-password'
     settings.ENABLE_CERTIFICATE_PUBLISHER = True
 
 

--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -298,6 +298,9 @@ def mt_course_completion_handler(instance, **kwargs):  # pylint: disable=unused-
     Arguments:
         instance<Blockcompletion>: Instance of BlockCompletion model.
     """
+    if not getattr(settings, "ACTIVATE_MT_COMPLETION_UPDATER", False):
+        return
+
     course_completion_mt_updater.delay(
         user_id=instance.user_id,
         course_id=str(instance.context_key),
@@ -313,6 +316,9 @@ def mt_course_passed_handler(user, course_id, **kwargs):  # pylint: disable=unus
         user <User>: Instance of auth user model.
         course_id <CourseLocator>: Course locator.
     """
+    if not getattr(settings, "ACTIVATE_MT_TRAINING_STAGE", False):
+        return
+
     update_mt_training_stage.delay(
         course_id=str(course_id),
         national_id=user.username,
@@ -328,6 +334,9 @@ def mt_course_failed_handler(user, course_id, **kwargs):  # pylint: disable=unus
         user <User>: Instance of auth user model.
         course_id <CourseLocator>: Course locator.
     """
+    if not getattr(settings, "ACTIVATE_MT_COMPLETION_UPDATER", False):
+        return
+
     course_completion_mt_updater.delay(
         user_id=user.id,
         course_id=str(course_id),

--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -301,6 +301,7 @@ def mt_course_completion_handler(instance, **kwargs):  # pylint: disable=unused-
     course_completion_mt_updater.delay(
         user_id=instance.user_id,
         course_id=str(instance.context_key),
+        stage_result=1,
     )
 
 
@@ -327,8 +328,9 @@ def mt_course_failed_handler(user, course_id, **kwargs):  # pylint: disable=unus
         user <User>: Instance of auth user model.
         course_id <CourseLocator>: Course locator.
     """
-    update_mt_training_stage.delay(
+    course_completion_mt_updater.delay(
+        user_id=user.id,
         course_id=str(course_id),
-        national_id=user.username,
         stage_result=2,
+        force_graded=True,
     )

--- a/eox_nelp/signals/tasks.py
+++ b/eox_nelp/signals/tasks.py
@@ -224,9 +224,6 @@ def update_mt_training_stage(course_id, national_id, stage_result):
         national_id (str): User identifier.
         stage_result (int): Representation of pass or fail result, 1 for pass  2 for fail.
     """
-    if not getattr(settings, "ACTIVATE_MT_TRAINING_STAGE", False):
-        return
-
     api_client = MinisterOfTourismApiClient()
 
     api_client.update_training_stage(
@@ -247,9 +244,6 @@ def course_completion_mt_updater(user_id, course_id, stage_result, force_graded=
         course_id (str): Unique course identifier.
         national_id (str): User identifier.
     """
-    if not getattr(settings, "ACTIVATE_MT_COMPLETION_UPDATER", False):
-        return
-
     user = User.objects.get(id=user_id)
     course_key = CourseKey.from_string(course_id)
     descriptor = modulestore().get_course(course_key)

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -576,6 +576,23 @@ class MtCourseCompletionHandlerTestCase(unittest.TestCase):
     """Test class for mt_course_completion_handler function."""
 
     @patch("eox_nelp.signals.receivers.course_completion_mt_updater")
+    def test_invalid_feature_flag(self, task_mock):
+        """Test when the ACTIVATE_MT_COMPLETION_UPDATER settings is False.
+
+        Expected behavior:
+            - modulestore mock has not been called.
+        """
+        instance = Mock()
+        instance.user_id = 5
+        course_id = "course-v1:test+Cx105+2022_T4"
+        instance.context_key = CourseKey.from_string(course_id)
+
+        mt_course_completion_handler(instance)
+
+        task_mock.delay.assert_not_called()
+
+    @override_settings(ACTIVATE_MT_COMPLETION_UPDATER=True)
+    @patch("eox_nelp.signals.receivers.course_completion_mt_updater")
     def test_call_async_task(self, task_mock):
         """Test that the async task is called with the right parameters
 
@@ -600,6 +617,21 @@ class MtCoursePassedHandlerTestCase(unittest.TestCase):
     """Test class for mt_course_passed_handler function."""
 
     @patch("eox_nelp.signals.receivers.update_mt_training_stage")
+    def test_invalid_feature_flag(self, task_mock):
+        """Test when the ACTIVATE_MT_TRAINING_STAGE settings is False.
+
+        Expected behavior:
+            - MinisterOfTourismApiClient mock has not been called.
+        """
+        course_id = "course-v1:test+Cx105+2022_T4"
+        user_instance, _ = User.objects.get_or_create(username="Severus")
+
+        mt_course_passed_handler(user_instance, CourseKey.from_string(course_id))
+
+        task_mock.delay.assert_not_called()
+
+    @override_settings(ACTIVATE_MT_TRAINING_STAGE=True)
+    @patch("eox_nelp.signals.receivers.update_mt_training_stage")
     def test_call_async_task(self, task_mock):
         """Test that the async task is called with the right parameters
 
@@ -621,6 +653,21 @@ class MtCoursePassedHandlerTestCase(unittest.TestCase):
 class MtCourseFailedHandlerTestCase(unittest.TestCase):
     """Test class for mt_course_failed_handler function."""
 
+    @patch("eox_nelp.signals.receivers.course_completion_mt_updater")
+    def test_invalid_feature_flag(self, task_mock):
+        """Test when the ACTIVATE_MT_COMPLETION_UPDATER settings is False.
+
+        Expected behavior:
+            - modulestore mock has not been called.
+        """
+        course_id = "course-v1:test+Cx105+2022_T4"
+        user_instance, _ = User.objects.get_or_create(username="Severus")
+
+        mt_course_failed_handler(user_instance, CourseKey.from_string(course_id))
+
+        task_mock.delay.assert_not_called()
+
+    @override_settings(ACTIVATE_MT_COMPLETION_UPDATER=True)
     @patch("eox_nelp.signals.receivers.course_completion_mt_updater")
     def test_call_async_task(self, task_mock):
         """Test that the async task is called with the right parameters

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -592,6 +592,7 @@ class MtCourseCompletionHandlerTestCase(unittest.TestCase):
         task_mock.delay.assert_called_with(
             user_id=instance.user_id,
             course_id=course_id,
+            stage_result=1,
         )
 
 
@@ -620,7 +621,7 @@ class MtCoursePassedHandlerTestCase(unittest.TestCase):
 class MtCourseFailedHandlerTestCase(unittest.TestCase):
     """Test class for mt_course_failed_handler function."""
 
-    @patch("eox_nelp.signals.receivers.update_mt_training_stage")
+    @patch("eox_nelp.signals.receivers.course_completion_mt_updater")
     def test_call_async_task(self, task_mock):
         """Test that the async task is called with the right parameters
 
@@ -633,7 +634,8 @@ class MtCourseFailedHandlerTestCase(unittest.TestCase):
         mt_course_failed_handler(user_instance, CourseKey.from_string(course_id))
 
         task_mock.delay.assert_called_with(
+            user_id=user_instance.id,
             course_id=course_id,
-            national_id=user_instance.username,
             stage_result=2,
+            force_graded=True,
         )

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -5,6 +5,9 @@ Classes:
     IncludeTrackerContextTestCase: Test include_tracker_context receiver.
     UpdateAsyncTrackerContextTestCase: Test update_async_tracker_context receiver.
     EmitSubsectionAttemptEventTestCase: Test emit_subsection_attempt_event receiver.
+    MtCourseCompletionHandlerTestCase: Test mt_course_completion_handler receiver.
+    MtCoursePassesHandlerTestCase: Test mt_course_passed_handler receiver.
+    MtCourseFailedHandlerTestCase: Test mt_course_failed_handler receiver.
 """
 import unittest
 
@@ -27,6 +30,9 @@ from eox_nelp.signals.receivers import (
     emit_subsection_attempt_event,
     enrollment_publisher,
     include_tracker_context,
+    mt_course_completion_handler,
+    mt_course_failed_handler,
+    mt_course_passed_handler,
     update_async_tracker_context,
 )
 from eox_nelp.tests.utils import set_key_values
@@ -563,4 +569,71 @@ class EmitSubsectionAttemptEventTestCase(unittest.TestCase):
         task_mock.delay.assert_called_with(
             usage_id=usage_id,
             user_id=user_id,
+        )
+
+
+class MtCourseCompletionHandlerTestCase(unittest.TestCase):
+    """Test class for mt_course_completion_handler function."""
+
+    @patch("eox_nelp.signals.receivers.course_completion_mt_updater")
+    def test_call_async_task(self, task_mock):
+        """Test that the async task is called with the right parameters
+
+        Expected behavior:
+            - delay method is called with the right values.
+        """
+        instance = Mock()
+        instance.user_id = 5
+        course_id = "course-v1:test+Cx105+2022_T4"
+        instance.context_key = CourseKey.from_string(course_id)
+
+        mt_course_completion_handler(instance)
+
+        task_mock.delay.assert_called_with(
+            user_id=instance.user_id,
+            course_id=course_id,
+        )
+
+
+class MtCoursePassedHandlerTestCase(unittest.TestCase):
+    """Test class for mt_course_passed_handler function."""
+
+    @patch("eox_nelp.signals.receivers.update_mt_training_stage")
+    def test_call_async_task(self, task_mock):
+        """Test that the async task is called with the right parameters
+
+        Expected behavior:
+            - delay method is called with the right values.
+        """
+        course_id = "course-v1:test+Cx105+2022_T4"
+        user_instance, _ = User.objects.get_or_create(username="Severus")
+
+        mt_course_passed_handler(user_instance, CourseKey.from_string(course_id))
+
+        task_mock.delay.assert_called_with(
+            course_id=course_id,
+            national_id=user_instance.username,
+            stage_result=1,
+        )
+
+
+class MtCourseFailedHandlerTestCase(unittest.TestCase):
+    """Test class for mt_course_failed_handler function."""
+
+    @patch("eox_nelp.signals.receivers.update_mt_training_stage")
+    def test_call_async_task(self, task_mock):
+        """Test that the async task is called with the right parameters
+
+        Expected behavior:
+            - delay method is called with the right values.
+        """
+        course_id = "course-v1:test+Cx105+2022_T4"
+        user_instance, _ = User.objects.get_or_create(username="Severus")
+
+        mt_course_failed_handler(user_instance, CourseKey.from_string(course_id))
+
+        task_mock.delay.assert_called_with(
+            course_id=course_id,
+            national_id=user_instance.username,
+            stage_result=2,
         )

--- a/eox_nelp/signals/tests/test_tasks.py
+++ b/eox_nelp/signals/tests/test_tasks.py
@@ -508,26 +508,6 @@ class UpdateMtTrainingStageTestCase(unittest.TestCase):
     """Test class for update_mt_training_stage function"""
 
     @patch("eox_nelp.signals.tasks.MinisterOfTourismApiClient")
-    def test_invalid_feature_flag(self, api_mock):
-        """Test when the ACTIVATE_MT_TRAINING_STAGE settings is False.
-
-        Expected behavior:
-            - MinisterOfTourismApiClient mock has not been called.
-        """
-        course_id = "course-v1:test+Cx105+2022_T4"
-        national_id = "1245789652"
-        stage_result = 1
-
-        update_mt_training_stage(
-            course_id=course_id,
-            national_id=national_id,
-            stage_result=stage_result,
-        )
-
-        api_mock.assert_not_called()
-
-    @override_settings(ACTIVATE_MT_TRAINING_STAGE=True)
-    @patch("eox_nelp.signals.tasks.MinisterOfTourismApiClient")
     def test_update_training_stage_call(self, api_mock):
         """Test when the feature flag has been set and the api call has been executed.
 
@@ -578,26 +558,11 @@ class CourseCompletionMtUpdaterTestCase(unittest.TestCase):
         course_key = CourseKey.from_string(self.course_id)
         store.get_course.assert_called_once_with(course_key)
 
-    def test_invalid_feature_flag(self):
-        """Test when the ACTIVATE_MT_COMPLETION_UPDATER settings is False.
-
-        Expected behavior:
-            - modulestore mock has not been called.
-        """
-        course_completion_mt_updater(
-            user_id=20,
-            course_id=self.course_id,
-            stage_result=1,
-        )
-
-        modulestore.assert_not_called()
-
     @data(([], True), ([1, 2, 3], False))
-    @override_settings(ACTIVATE_MT_COMPLETION_UPDATER=True)
     @patch("eox_nelp.signals.tasks._get_completion_summary")
     @patch("eox_nelp.signals.tasks.update_mt_training_stage")
     def test_invalid_grading_conditions(self, test_data, updater_mock, completion_summary_mock):
-        """Test when followingconditions are not met:
+        """Test when following conditions are not met:
             1. Course is graded and the force_graded parameter is False.
             2. Course is not graded and the force_graded parameter is True.
 
@@ -618,7 +583,6 @@ class CourseCompletionMtUpdaterTestCase(unittest.TestCase):
 
         updater_mock.assert_not_called()
 
-    @override_settings(ACTIVATE_MT_COMPLETION_UPDATER=True)
     @patch("eox_nelp.signals.tasks._get_completion_summary")
     @patch("eox_nelp.signals.tasks.update_mt_training_stage")
     def test_invalid_completion_summary(self, updater_mock, completion_summary_mock):
@@ -642,7 +606,6 @@ class CourseCompletionMtUpdaterTestCase(unittest.TestCase):
         self.mock_validations()
 
     @data(([1, 2, 3], True), ([], False))
-    @override_settings(ACTIVATE_MT_COMPLETION_UPDATER=True)
     @patch("eox_nelp.signals.tasks._get_completion_summary")
     @patch("eox_nelp.signals.tasks.update_mt_training_stage")
     def test_update_mt_training_stage_call(self, test_data, updater_mock, completion_summary_mock):


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This adds a new API client for MT and also adds new celery tasks that allows to update the training stage,for more details, check this [ticket](https://edunext.atlassian.net/browse/FUTUREX-675)

Tasks are connected to following django signals:

Post save BlockCompletion:  If the course doesn't have any grading policy and the user has complete the course, the tasks will make a post with the following data:
```
{
  "courseLMSId": "<course_id>",
  "userNationalId": "<user.username>",
  "applicationStageResult": 1    // PASS representation
}
```

COURSE_GRADE_NOW_PASSED: If the user has got a passed grade, the tasks will make a post with the following data:
```
{
  "courseLMSId": "<course_id>",
  "userNationalId": "<user.username>",
  "applicationStageResult": 1    // PASS representation
}
```
COURSE_GRADE_NOW_FAILED:  If the user hasn't got a passed grade, the tasks will make a post with the following data:
```
{
  "courseLMSId": "<course_id>",
  "userNationalId": "<user.username>",
  "applicationStageResult": 2    // FAIL representation
}
```
## Testing instructions
1. Set settings, you can get the api credentials in the postman collection that is shared in the [ticket](https://edunext.atlassian.net/browse/FUTUREX-675)
ACTIVATE_MT_COMPLETION_UPDATER = True
ACTIVATE_MT_TRAINING_STAGE = True
MINISTER_OF_TOURISM_USER = "<user>"
MINISTER_OF_TOURISM_PASSWORD = "<pass>"
MINISTER_OF_TOURISM_API_URL = "<url>"

2. Create two courses, one with grading policies and another without grading policies 
3. Complete both courses and check eox audit model 

### Expected result

###### PASS
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/ee57864a-5bee-4cb0-b24b-01d208916790)

###### FAIL 
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/898092b5-e00a-41b8-acea-02436ff452b8)


## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
