### PR TITLE
feat: return signup source records in learner metrics

### DIFF
--- a/eox_nelp/edxapp_wrapper/test_backends/users_p_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/users_p_v1.py
@@ -1,0 +1,21 @@
+"""Test backend for eox-coreusers module."""
+from django.contrib.auth.models import User
+from django.db import models
+
+from eox_nelp.edxapp_wrapper.test_backends import create_test_model
+
+
+def get_user_signup_source():
+    """Return test model.
+
+    Returns:
+        UserSignupSource dummy model.
+    """
+    user_signup_source_fields = {
+        "user": models.ForeignKey(User, db_index=True, on_delete=models.CASCADE),
+        "site": models.CharField(max_length=255, db_index=True),
+    }
+
+    return create_test_model(
+        "UserSignupSource", "eox_nelp", __package__, user_signup_source_fields,
+    )

--- a/eox_nelp/migrations/0001_initial.py
+++ b/eox_nelp/migrations/0001_initial.py
@@ -106,6 +106,14 @@ class Migration(migrations.Migration):
                 ('mode', models.CharField(default='honor', max_length=32, choices=[('verified', 'verified'), ('honor', 'honor'), ('audit', 'audit'), ('professional', 'professional'), ('no-id-professional', 'no-id-professional')])),
             ],
         ),
+        migrations.CreateModel(
+            name='UserSignupSource',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
+                ('site', models.CharField(default='', max_length=255)),
+            ],
+        ),
     ]
 
     if getattr(settings, 'TESTING_MIGRATIONS', False):

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -113,6 +113,7 @@ EOX_THEMING_CONFIG_SOURCES = [
 EOX_CORE_COURSEWARE_BACKEND = "eox_nelp.edxapp_wrapper.test_backends.courseware_m_v1"
 EOX_CORE_GRADES_BACKEND = "eox_nelp.edxapp_wrapper.test_backends.grades_m_v1"
 EOX_CORE_CERTIFICATES_BACKEND = "eox_nelp.edxapp_wrapper.test_backends.certificates_m_v1"
+EOX_CORE_USERS_BACKEND = "eox_nelp.edxapp_wrapper.test_backends.users_p_v1"
 
 GET_SITE_CONFIGURATION_MODULE = 'eox_tenant.edxapp_wrapper.backends.site_configuration_module_test_v1'
 GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_test_v1'


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This adds users from user singup source records to the get_learners_metric result, basically this metric will take into account two conditions  user that are enrolled in a tenant course and users that completed the signup process at that tenant.

## Testing instructions
1. Go to `/eox-nelp/api/stats/v1/tenant/`
2. Check the value of the field learners
3. Verify that the returned value is  (Total of  enrollments for course of the current tenant ) + (Total of  signup source records that belong to the current tenant)

**Note**

The metric doesn't return duplicates, so if the user completed the signup process in the current tenant and has at least one enrollment, the metric will return  1

On development environments the signupsource records uses the port, probably you will have to remove that, since the request.site.domain doesn't use the port
