### PR TITLE
Jlc/pearson vue/payload manipulations

### DIFF
--- a/eox_nelp/pearson_vue/constants.py
+++ b/eox_nelp/pearson_vue/constants.py
@@ -1,0 +1,87 @@
+"""Module to add constants related Pearson Vue Integration"""
+# flake8: noqa: E501
+# pylint: disable=duplicate-code
+
+PAYLOAD_PING = """
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:sch="http://ws.pearsonvue.com/ping/schema">
+    <soapenv:Header/>
+    <soapenv:Body>
+    <sch:pingServiceRequest/>
+    </soapenv:Body>
+</soapenv:Envelope>
+"""
+
+PAYLOAD_PING_DATABASE = """
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:sch="http://ws.pearsonvue.com/ping/schema">
+    <soapenv:Header>
+        <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" soapenv:mustUnderstand="1">
+            <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="UsernameToken-28678335">
+                <wsse:Username></wsse:Username>
+                <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"></wsse:Password>
+            </wsse:UsernameToken>
+        </wsse:Security>
+    </soapenv:Header>
+    <soapenv:Body>
+        <sch:pingDatabaseRequest />
+    </soapenv:Body>
+</soapenv:Envelope>
+"""
+
+PAYLOAD_CDD = """
+<soapenv:Envelope xmlns:sch="http://ws.pearsonvue.com/rti/cdd/schema" xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
+    <soapenv:Header>
+        <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" soapenv:mustUnderstand="1">
+            <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="UsernameToken-26398355">
+                <wsse:Username></wsse:Username>
+                <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"></wsse:Password>
+            </wsse:UsernameToken>
+        </wsse:Security>
+    </soapenv:Header>
+    <soapenv:Body>
+        <sch:cddRequest clientCandidateID="" clientID="">
+            <candidateName>
+                <firstName></firstName>
+                <lastName></lastName>
+            </candidateName>
+            <webAccountInfo>
+                <email></email>
+            </webAccountInfo>
+            <lastUpdate></lastUpdate>
+            <primaryAddress>
+                <address1></address1>
+                <city></city>
+                <country></country>
+                <phone>
+                    <phoneNumber></phoneNumber>
+                    <phoneCountryCode></phoneCountryCode>
+                </phone>
+                <mobile>
+                    <mobileNumber></mobileNumber>
+                    <mobileCountryCode></mobileCountryCode>
+                </mobile>
+            </primaryAddress>
+        </sch:cddRequest>
+    </soapenv:Body>
+</soapenv:Envelope>
+"""
+PAYLOAD_EAD = """
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:sch="http://ws.pearsonvue.com/rti/ead/schema">
+    <soapenv:Header>
+        <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" soapenv:mustUnderstand="1">
+            <wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="UsernameToken-26398355">
+                <wsse:Username></wsse:Username>
+                <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"></wsse:Password>
+            </wsse:UsernameToken>
+        </wsse:Security>
+    </soapenv:Header>
+    <soapenv:Body>
+        <sch:eadRequest clientID="" authorizationTransactionType="">
+            <examAuthorizationCount></examAuthorizationCount>
+            <examSeriesCode></examSeriesCode>
+            <eligibilityApptDateFirst></eligibilityApptDateFirst>
+            <eligibilityApptDateLast></eligibilityApptDateLast>
+            <lastUpdate></lastUpdate>
+        </sch:eadRequest>
+    </soapenv:Body>
+</soapenv:Envelope>
+"""

--- a/eox_nelp/pearson_vue/tests/test_utils.py
+++ b/eox_nelp/pearson_vue/tests/test_utils.py
@@ -1,0 +1,361 @@
+"""This file contains all the test for the pearson vue  utils.py file.
+
+Classes:
+    UpdatePayloadCddRequestTestCase: Tests cases for update_xml_with_dict using payload with cdd request tag cases.
+    UpdatePayloadEadRequestTestCase: Test cased for update_xml_with_dict using payload with ead request tag cases.
+"""
+import xmltodict
+from bs4 import BeautifulSoup
+from django.test import TestCase
+
+from eox_nelp.pearson_vue.constants import PAYLOAD_CDD, PAYLOAD_EAD
+from eox_nelp.pearson_vue.utils import update_xml_with_dict
+
+
+class UpdatePayloadCddRequestTestCase(TestCase):
+    """Test case for update_xml focus on cddRequest tag with dict"""
+
+    def setUp(self):
+        """Setup common conditions for every test case"""
+        self.payload_base = PAYLOAD_CDD
+        self.payload_base_bs = BeautifulSoup(PAYLOAD_CDD, "xml")
+
+    def test_cdd_request_not_modified(self):
+        """Test update_xml_with_dict method doesn't modify PAYLOAD_CDD
+        using an empty update_dict .
+
+        Expected behavior:
+            - payload_base dict representation is the same to the payload_result dict representation.
+        """
+        update_dict = {}
+
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+
+        self.assertDictEqual(xmltodict.parse(self.payload_base), xmltodict.parse(payload_result))
+
+    def test_username_password_modified(self):
+        """Test username and password are modified in the
+          new payload string
+          using update_xml_with_dict.
+
+        Expected behavior:
+            - Using payload bs representation username text is modified.
+            - Using payload bs representation password text is modified.
+        """
+        username = "darth"
+        password = "vaderpass"
+        update_dict = {
+            "soapenv:Envelope": {
+                "soapenv:Header": {
+                    "wsse:Security": {
+                        "wsse:UsernameToken": {
+                            "wsse:Username": username,
+                            'wsse:Password': {
+                                '#text': password
+                            },
+                        }
+                    }
+                }
+            }
+        }
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+        payload_result_bs = BeautifulSoup(payload_result, "xml")
+
+        self.assertEqual(payload_result_bs.find("wsse:Username").text, username)
+        self.assertEqual(payload_result_bs.find("wsse:Password").text, password)
+
+    def test_cdd_request_modify_attrs(self):
+        """Test update_xml_with_dict method modify PAYLOAD_CDD
+        in the sch:cddRequest tag attributes using configure update_dict with `@` .
+
+        Expected behavior:
+            - payload_base dict representation is not the same to the payload_result dict representation.
+            - result_attrs of the new payload using bs are the same to the update dict.
+        """
+        update_dict = {
+            "soapenv:Envelope": {
+                "soapenv:Body": {
+                    "sch:cddRequest": {
+                        "@clientCandidateID": "newclientcandidateID",
+                        "@clientID": "123999222ID",
+                    }
+                }
+            }
+        }
+
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+        payload_result_bs = BeautifulSoup(payload_result, "xml")
+
+        self.assertNotEqual(xmltodict.parse(self.payload_base), xmltodict.parse(payload_result))
+        result_cdd_request_attrs = payload_result_bs.find("sch:cddRequest").attrs
+        for key in result_cdd_request_attrs:
+            self.assertEqual(
+                result_cdd_request_attrs[key],
+                update_dict["soapenv:Envelope"]["soapenv:Body"]["sch:cddRequest"][f"@{key}"]
+            )
+
+    def test_cdd_request_modify_candidate_name(self):
+        """Test update_xml_with_dict method modify PAYLOAD_CDD
+        in the candidateName tags  using update_dict.
+
+        Expected behavior:
+            - payload_base dict representation is not the same to the payload_result dict representation.
+            - text of CandidateName keys of the new payload using bs are the same to the update dict.
+        """
+        update_dict = {
+            "soapenv:Envelope": {
+                "soapenv:Body": {
+                    "sch:cddRequest": {
+                        "candidateName": {
+                            "firstName": "Darth",
+                            "lastName": "Vader",
+                            "middleName": "Anakin",
+                            "salutation": "Mr",
+                            "suffix": "Lord",
+                        }
+                    }
+                }
+            }
+        }
+
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+        payload_result_bs = BeautifulSoup(payload_result, "xml")
+
+        self.assertNotEqual(xmltodict.parse(self.payload_base), xmltodict.parse(payload_result))
+        for key, _ in update_dict["soapenv:Envelope"]["soapenv:Body"]["sch:cddRequest"]["candidateName"].items():
+            self.assertEqual(
+                payload_result_bs.find(key).text,
+                update_dict["soapenv:Envelope"]["soapenv:Body"]["sch:cddRequest"]["candidateName"][key]
+            )
+
+    def test_cdd_request_modify_web_account_info(self):
+        """Test update_xml_with_dict method modify PAYLOAD_CDD
+        in the webAccountInfo tag using update_dict.
+
+        Expected behavior:
+            - payload_base dict representation is not the same to the payload_result dict representation.
+            - text of email tag of the new payload using bs is the same to the update dict.
+        """
+        update_dict = {
+            "soapenv:Envelope": {
+                "soapenv:Body": {
+                    "sch:cddRequest": {
+                        "webAccountInfo": {
+                            "email": "vader@mail.com"
+                        }
+                    }
+                }
+            }
+        }
+
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+        payload_result_bs = BeautifulSoup(payload_result, "xml")
+
+        self.assertNotEqual(xmltodict.parse(self.payload_base), xmltodict.parse(payload_result))
+        self.assertEqual(
+            payload_result_bs.find("email").text,
+            update_dict["soapenv:Envelope"]["soapenv:Body"]["sch:cddRequest"]["webAccountInfo"]["email"]
+        )
+
+    def test_cdd_request_modify_last_update(self):
+        """Test update_xml_with_dict method modify PAYLOAD_CDD
+        in the lastUpdate tag  using update_dict.
+
+        Expected behavior:
+            - payload_base dict representation is not the same to the payload_result dict representation.
+            - text of email tag of the new payload using bs is the same to the update dict.
+        """
+        update_dict = {
+            "soapenv:Envelope": {
+                "soapenv:Body": {
+                    "sch:cddRequest": {
+                        "lastUpdate": "2033/04/14 09:35:18 GMT"
+                    }
+                }
+            }
+        }
+
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+        payload_result_bs = BeautifulSoup(payload_result, "xml")
+
+        self.assertNotEqual(xmltodict.parse(self.payload_base), xmltodict.parse(payload_result))
+        self.assertEqual(
+            payload_result_bs.find("lastUpdate").text,
+            update_dict["soapenv:Envelope"]["soapenv:Body"]["sch:cddRequest"]["lastUpdate"]
+        )
+
+    def test_cdd_request_modify_address_info(self):
+        """Test update_xml_with_dict method modify PAYLOAD_CDD
+        in the primaryAddress and alternateAddress tags using update_dict.
+
+        Expected behavior:
+            - payload_base dict representation is not the same to the payload_result dict representation.
+            - primaryAddress dict-key of the new_payload_dict representation is the same to update_dict.
+            - alternateAddress dict-key of the new_payload_dict representation is the same to update_dict.
+
+        """
+        update_dict = {
+            "soapenv:Envelope": {
+                "soapenv:Body": {
+                    "sch:cddRequest": {
+                        "primaryAddress": {
+                            "addressType": "Work",
+                            "companyName": "Pearson VUE Clark Kent",
+                            "address1": "5601 Green Valley Drive",
+                            "address2": "Suite 220",
+                            "city": "Smallville",
+                            "state": "kansas",
+                            "postalCode": "55437",
+                            "country": "USA",
+                            "phone": {
+                                "phoneNumber": "99999999",
+                                "phoneCountryCode": "1"
+                            },
+                            "mobile": {
+                                "mobileNumber": "88888888",
+                                "mobileCountryCode": "1"
+                            },
+                        },
+                        "alternateAddress": {
+                            "addressType": "Home",
+                            "address1": "123 Antartic",
+                            "city": "Polar",
+                            "state": "cold",
+                            "postalCode": "55379",
+                            "country": "USA",
+                            "phone": {
+                                "phoneNumber": "000000000",
+                                "extension": "89",
+                                "phoneCountryCode": "1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+
+        self.assertNotEqual(xmltodict.parse(self.payload_base), xmltodict.parse(payload_result))
+        self.assertDictEqual(
+            xmltodict.parse(payload_result)["soapenv:Envelope"]["soapenv:Body"]["sch:cddRequest"]["primaryAddress"],
+            update_dict["soapenv:Envelope"]["soapenv:Body"]["sch:cddRequest"]["primaryAddress"],
+        )
+        self.assertDictEqual(
+            xmltodict.parse(payload_result)["soapenv:Envelope"]["soapenv:Body"]["sch:cddRequest"]["alternateAddress"],
+            update_dict["soapenv:Envelope"]["soapenv:Body"]["sch:cddRequest"]["alternateAddress"],
+        )
+
+
+class UpdatePayloadEadRequestTestCase(TestCase):
+    """Test case for update_xml focus on eadRequest tag with dict"""
+
+    def setUp(self):
+        """Setup common conditions for every test case"""
+        self.payload_base = PAYLOAD_EAD
+        self.payload_base_bs = BeautifulSoup(PAYLOAD_EAD, "xml")
+
+    def test_ead_request_not_modified(self):
+        """Test update_xml_with_dict method doesn't modify PAYLOAD_EAD
+        using an empty update_dict .
+
+        Expected behavior:
+            - payload_base dict representation is the same to the payload_result dict representation.
+        """
+        update_dict = {}
+
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+
+        self.assertDictEqual(xmltodict.parse(self.payload_base), xmltodict.parse(payload_result))
+
+    def test_username_password_modified(self):
+        """Test username and password are modified in the
+          new payload string
+          using update_xml_with_dict.
+
+        Expected behavior:
+            - Using payload bs representation username text is modified.
+            - Using payload bs representation password text is modified.
+        """
+        username = "darth"
+        password = "vaderpass"
+        update_dict = {
+            "soapenv:Envelope": {
+                "soapenv:Header": {
+                    "wsse:Security": {
+                        "wsse:UsernameToken": {
+                            "wsse:Username": username,
+                            'wsse:Password': {
+                                '#text': password
+                            },
+                        }
+                    }
+                }
+            }
+        }
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+        payload_result_bs = BeautifulSoup(payload_result, "xml")
+
+        self.assertEqual(payload_result_bs.find("wsse:Username").text, username)
+        self.assertEqual(payload_result_bs.find("wsse:Password").text, password)
+
+    def test_ead_request_modify_attrs(self):
+        """Test update_xml_with_dict method modify PAYLOAD_EAD
+        in the sch:cddRequest tag attributes using configure update_dict with `@` .
+
+        Expected behavior:
+            - payload_base dict representation is not the same to the payload_result dict representation.
+            - result_attrs of the new payload using bs are the same to the update dict.
+        """
+        update_dict = {
+            "soapenv:Envelope": {
+                "soapenv:Body": {
+                    "sch:eadRequest": {
+                        "@clientID": "00000000ID",
+                        "@authorizationTransactionType": "Update",
+                        "@clientAuthorizationID": "A9999",
+                    }
+                }
+            }
+        }
+
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+        payload_result_bs = BeautifulSoup(payload_result, "xml")
+
+        self.assertNotEqual(xmltodict.parse(self.payload_base), xmltodict.parse(payload_result))
+        result_cdd_request_attrs = payload_result_bs.find("sch:eadRequest").attrs
+        for key in result_cdd_request_attrs:
+            self.assertEqual(
+                result_cdd_request_attrs[key],
+                update_dict["soapenv:Envelope"]["soapenv:Body"]["sch:eadRequest"][f"@{key}"]
+            )
+
+    def test_ead_request_modify_all_info(self):
+        """Test update_xml_with_dict method modify PAYLOAD_EAD
+        in the sch:eadRequest nested tags using update_dict.
+
+        Expected behavior:
+            - payload_base dict representation is not the same to the payload_result dict representation.
+            - text of CandidateName tag of the new payload using bs are the same to the update dict.
+        """
+        update_dict = {
+            "soapenv:Envelope": {
+                "soapenv:Body": {
+                    "sch:eadRequest": {
+                        "clientCandidateID": "Superman123456",
+                        "examAuthorizationCount": "5",
+                        "examSeriesCode": "OTT2",
+                        "eligibilityApptDateFirst": "2024/05/01 00:00:00",
+                        "eligibilityApptDateLast": "3256/12/31 23:59:59",
+                        "lastUpdate": "2024/05/16 23:09:01 GMT",
+                    }
+                }
+            }
+        }
+
+        payload_result = update_xml_with_dict(self.payload_base, update_dict)
+        payload_result_bs = BeautifulSoup(payload_result, "xml")
+
+        self.assertNotEqual(xmltodict.parse(self.payload_base), xmltodict.parse(payload_result))
+        for key, value in update_dict["soapenv:Envelope"]["soapenv:Body"]["sch:eadRequest"].items():
+            self.assertEqual(payload_result_bs.find(key).text, value)

--- a/eox_nelp/pearson_vue/utils.py
+++ b/eox_nelp/pearson_vue/utils.py
@@ -1,0 +1,28 @@
+"""Utils that can be used for the pearson Vue integration.
+This includes xml helpers:
+    - update_xml_with_dict
+"""
+import xmltodict
+from pydantic.v1.utils import deep_update
+
+
+def update_xml_with_dict(xml: str, update_dict: dict) -> str:
+    """Update an xml string using its dict representation, deep_update,
+    and auxiliar update_dict using xmltodict
+    nomenclature: (keys~tags, values~text, attrs~@keys).
+    https://github.com/martinblech/xmltodict
+    https://pypi.org/project/xmltodict/
+    To update the dict is used deep_update method of pydantic.https://docs.pydantic.dev/latest/
+    https://github.com/pydantic/pydantic/blob/15b82a90c9f20db0ce618caffe6b4cb3c05ba139/pydantic/v1/utils.py#L213
+
+    Args:
+        xml (str): str xml payload to update.
+        update_dict (dict): Update_dict representation to update xml_dict representation in the
+        corresponding tags.
+
+    Returns:
+        updated_xml(str): string xml representation of the updated_dict representation.
+    """
+    xml_dict = xmltodict.parse(xml)
+    result = deep_update(xml_dict, update_dict)
+    return xmltodict.unparse(result, full_document=False)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -19,7 +19,9 @@ event-tracking
 mako
 openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters
+pydantic
 requests-oauthlib
 requests-pkcs12==1.22
 social-auth-app-django
 tincan
+xmltodict==0.13.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,8 @@ amqp==5.2.0
     # via kombu
 aniso8601==9.0.1
     # via tincan
+annotated-types==0.6.0
+    # via pydantic
 appdirs==1.4.4
     # via fs
 asgiref==3.8.1
@@ -185,7 +187,7 @@ edx-toggles==5.2.0
     # via event-tracking
 edx-when==2.5.0
     # via edx-proctoring
-eox-core==10.0.0
+eox-core==10.2.0
     # via -r requirements/base.in
 eox-tenant==11.2.0
     # via
@@ -265,6 +267,10 @@ pycryptodomex==3.20.0
     # via
     #   edx-proctoring
     #   pyjwkest
+pydantic==2.7.1
+    # via -r requirements/base.in
+pydantic-core==2.18.2
+    # via pydantic
 pyjwkest==1.4.2
     # via edx-drf-extensions
 pyjwt[crypto]==2.8.0
@@ -321,9 +327,7 @@ requests-oauthlib==2.0.0
     #   -r requirements/base.in
     #   social-auth-core
 requests-pkcs12==1.22
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+    # via -r requirements/base.in
 rules==3.3
     # via edx-proctoring
 semantic-version==2.10.0
@@ -368,6 +372,8 @@ typing-extensions==4.11.0
     #   asgiref
     #   edx-opaque-keys
     #   jwcrypto
+    #   pydantic
+    #   pydantic-core
 tzdata==2024.1
     # via celery
 uritemplate==4.1.1
@@ -387,6 +393,8 @@ webob==1.8.7
     # via xblock
 xblock==4.0.1
     # via edx-when
+xmltodict==0.13.0
+    # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,6 +12,10 @@ aniso8601==9.0.1
     # via
     #   -r requirements/base.txt
     #   tincan
+annotated-types==0.6.0
+    # via
+    #   -r requirements/base.txt
+    #   pydantic
 appdirs==1.4.4
     # via
     #   -r requirements/base.txt
@@ -254,7 +258,7 @@ edx-when==2.5.0
     # via
     #   -r requirements/base.txt
     #   edx-proctoring
-eox-core==10.0.0
+eox-core==10.2.0
     # via -r requirements/base.txt
 eox-tenant==11.2.0
     # via
@@ -392,6 +396,12 @@ pycryptodomex==3.20.0
     #   -r requirements/base.txt
     #   edx-proctoring
     #   pyjwkest
+pydantic==2.7.1
+    # via -r requirements/base.txt
+pydantic-core==2.18.2
+    # via
+    #   -r requirements/base.txt
+    #   pydantic
 pyflakes==3.2.0
     # via flake8
 pyjwkest==1.4.2
@@ -468,9 +478,7 @@ requests-oauthlib==2.0.0
     #   -r requirements/base.txt
     #   social-auth-core
 requests-pkcs12==1.22
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+    # via -r requirements/base.txt
 rules==3.3
     # via
     #   -r requirements/base.txt
@@ -542,6 +550,8 @@ typing-extensions==4.11.0
     #   astroid
     #   edx-opaque-keys
     #   jwcrypto
+    #   pydantic
+    #   pydantic-core
 tzdata==2024.1
     # via
     #   -r requirements/base.txt
@@ -576,6 +586,8 @@ xblock==4.0.1
     # via
     #   -r requirements/base.txt
     #   edx-when
+xmltodict==0.13.0
+    # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR add **xmltodict** package to add a dynamic way to update xml payloads.

The idea is to parse the xml string representation to dict representation. Then there update with the corresponding update_dict based in the tag purpose. Finally the dict representation is returned to the string representation.

There is a utils module  with 3 methods generated with the idea of modifying specific tags: 
- `<usernameToken>` -> update_payload_username_token
- `<scg:cddRequest>` -> update_payload_cdd_request
- `<scg:eadRequest>` -> update_payload_ead_request
So the 
This could be generalized, but I think that 3 is enough for this step.

Also, there is a constant file with the base xml string payloads for each use. I added with easier visual format.

### Extra info
Here is an example of the dict transform.
![image](https://github.com/eduNEXT/eox-nelp/assets/51926076/9947b38b-6e7e-4d1b-a82b-d4daada8a14e)
## Testing instructions

You could check the tests of how the update_dict different shapes could have based in the method.
Also, there is `@` special prefix to change attributes. 

For more info you could check in https://pypi.org/project/xmltodict/


## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
