### PR TITLE
Jlc/pearson vue/connect completion grading receivers

### DIFF
--- a/eox_nelp/apps.py
+++ b/eox_nelp/apps.py
@@ -101,6 +101,17 @@ class EoxNelpConfig(AppConfig):
                         'signal_path': 'openedx.core.djangoapps.signals.signals.COURSE_GRADE_NOW_FAILED',
                         'dispatch_uid': 'mt_course_failed_receiver',
                     },
+                    {
+                        'receiver_func_name': 'pearson_vue_course_completion_handler',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'dispatch_uid': 'pearson_vue_course_completion_receiver',
+                        'sender_path': 'completion.models.BlockCompletion',
+                    },
+                    {
+                        'receiver_func_name': 'pearson_vue_course_passed_handler',
+                        'signal_path': 'openedx.core.djangoapps.signals.signals.COURSE_GRADE_NOW_PASSED',
+                        'dispatch_uid': 'pearson_vue_course_passed_receiver',
+                    },
                 ],
             },
         },

--- a/eox_nelp/pearson_vue/constants.py
+++ b/eox_nelp/pearson_vue/constants.py
@@ -76,6 +76,7 @@ PAYLOAD_EAD = """
     </soapenv:Header>
     <soapenv:Body>
         <sch:eadRequest clientID="" authorizationTransactionType="">
+            <clientCandidateID></clientCandidateID>
             <examAuthorizationCount></examAuthorizationCount>
             <examSeriesCode></examSeriesCode>
             <eligibilityApptDateFirst></eligibilityApptDateFirst>

--- a/eox_nelp/pearson_vue/pipeline.py
+++ b/eox_nelp/pearson_vue/pipeline.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-def terminate_not_full_completion_cases(user_id, course_id, **kwargs):
+def handle_course_completion_status(user_id, course_id, **kwargs):
     """Pipeline that check the case of completion cases on the pipeline execution. Also this pipe
     has 4 behaviours depending the case:
         - skip this pipeline if setting PEARSON_RTI_TESTING_SKIP_CHECK_COMPLETION is truthy. Pipeline continues.
@@ -33,7 +33,8 @@ def terminate_not_full_completion_cases(user_id, course_id, **kwargs):
           The pipeline continues without changes.
         - is_complete=True and is_graded=False pipeline should continue.
           (completed courses and not graded).
-        - Otherwise the pipeline will stop, for grading-courses the COURSE_GRADE_NOW_PASSED signal would act.
+        - Otherwise this indicates that the pipeline execution would be stopped,
+          for grading-courses the COURSE_GRADE_NOW_PASSED signal would act.
 
     Args:
         user_id (int): The ID of the user whose data is to be retrieved.
@@ -43,9 +44,9 @@ def terminate_not_full_completion_cases(user_id, course_id, **kwargs):
     Returns:
         dict: Pipeline dict
     """
-    if getattr(settings, "PEARSON_RTI_TESTING_SKIP_FULL_COMPLETION_CASES", False):
+    if getattr(settings, "PEARSON_RTI_TESTING_SKIP_HANDLE_COURSE_COMPLETION_STATUS", False):
         logger.info(
-            "Skipping `terminate_not_full_completion_cases` pipe for user_id:%s and course_id: %s",
+            "Skipping `handle_course_completion_status` pipe for user_id:%s and course_id: %s",
             str(user_id),
             course_id
         )

--- a/eox_nelp/pearson_vue/pipeline.py
+++ b/eox_nelp/pearson_vue/pipeline.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-def check_completion_metadata(user_id, course_id, **kwargs):
+def terminate_not_full_completion_cases(user_id, course_id, **kwargs):
     """Pipeline that check the case of completion cases on the pipeline execution. Also this pipe
     has 3 behaviours depending the case:
         - is_passing is true means the course is graded(passed) and dont needs this pipe validation.
@@ -48,10 +48,7 @@ def check_completion_metadata(user_id, course_id, **kwargs):
     is_complete, is_graded = get_completed_and_graded(user_id, course_id)
 
     if is_complete and not is_graded:
-        return {
-            "is_complete": is_complete,
-            "is_graded": is_graded,
-        }
+        return None
 
     return {
         "safely_pipeline_termination": True,

--- a/eox_nelp/pearson_vue/pipeline.py
+++ b/eox_nelp/pearson_vue/pipeline.py
@@ -27,10 +27,11 @@ User = get_user_model()
 
 def terminate_not_full_completion_cases(user_id, course_id, **kwargs):
     """Pipeline that check the case of completion cases on the pipeline execution. Also this pipe
-    has 3 behaviours depending the case:
+    has 4 behaviours depending the case:
+        - skip this pipeline if setting PEARSON_RTI_TESTING_SKIP_CHECK_COMPLETION is truthy. Pipeline continues.
         - is_passing is true means the course is graded(passed) and dont needs this pipe validation.
           The pipeline continues without changes.
-        - is_complete=True and is_graded=False pipeline should continue with uploaded metadata
+        - is_complete=True and is_graded=False pipeline should continue.
           (completed courses and not graded).
         - Otherwise the pipeline will stop, for grading-courses the COURSE_GRADE_NOW_PASSED signal would act.
 
@@ -42,6 +43,14 @@ def terminate_not_full_completion_cases(user_id, course_id, **kwargs):
     Returns:
         dict: Pipeline dict
     """
+    if getattr(settings, "PEARSON_RTI_TESTING_SKIP_FULL_COMPLETION_CASES", False):
+        logger.info(
+            "Skipping `terminate_not_full_completion_cases` pipe for user_id:%s and course_id: %s",
+            str(user_id),
+            course_id
+        )
+        return None
+
     if kwargs.get("is_passing"):
         return None
 

--- a/eox_nelp/pearson_vue/pipeline.py
+++ b/eox_nelp/pearson_vue/pipeline.py
@@ -28,7 +28,8 @@ User = get_user_model()
 def handle_course_completion_status(user_id, course_id, **kwargs):
     """Pipeline that check the case of completion cases on the pipeline execution. Also this pipe
     has 4 behaviours depending the case:
-        - skip this pipeline if setting PEARSON_RTI_TESTING_SKIP_CHECK_COMPLETION is truthy. Pipeline continues.
+        - skip this pipeline if setting PEARSON_RTI_TESTING_SKIP_HANDLE_COURSE_COMPLETION_STATUS is truthy.
+          Pipeline continues.
         - is_passing is true means the course is graded(passed) and dont needs this pipe validation.
           The pipeline continues without changes.
         - is_complete=True and is_graded=False pipeline should continue.

--- a/eox_nelp/pearson_vue/rti_backend.py
+++ b/eox_nelp/pearson_vue/rti_backend.py
@@ -9,9 +9,9 @@ from eox_nelp.pearson_vue.pipeline import (
     check_service_availability,
     get_exam_data,
     get_user_data,
+    handle_course_completion_status,
     import_candidate_demographics,
     import_exam_authorization,
-    terminate_not_full_completion_cases,
 )
 
 
@@ -57,7 +57,7 @@ class RealTimeImport:
         Returns the RTI pipeline, which is a list of functions to be executed.
         """
         return [
-            terminate_not_full_completion_cases,
+            handle_course_completion_status,
             get_user_data,
             get_exam_data,
             check_service_availability,

--- a/eox_nelp/pearson_vue/rti_backend.py
+++ b/eox_nelp/pearson_vue/rti_backend.py
@@ -5,7 +5,7 @@ and executing various processes related to rti.
 Classes:
     RealTimeImport: Class for managing RTI operations and executing the pipeline.
 """
-from eox_nelp.pearson_vue.pipeline import get_user_data
+from eox_nelp.pearson_vue.pipeline import check_completion_metadata, get_user_data
 
 
 class RealTimeImport:
@@ -50,5 +50,6 @@ class RealTimeImport:
         Returns the RTI pipeline, which is a list of functions to be executed.
         """
         return [
+            check_completion_metadata,
             get_user_data,
         ]

--- a/eox_nelp/pearson_vue/rti_backend.py
+++ b/eox_nelp/pearson_vue/rti_backend.py
@@ -5,7 +5,14 @@ and executing various processes related to rti.
 Classes:
     RealTimeImport: Class for managing RTI operations and executing the pipeline.
 """
-from eox_nelp.pearson_vue.pipeline import get_user_data, terminate_not_full_completion_cases
+from eox_nelp.pearson_vue.pipeline import (
+    check_service_availability,
+    get_exam_data,
+    get_user_data,
+    import_candidate_demographics,
+    import_exam_authorization,
+    terminate_not_full_completion_cases,
+)
 
 
 class RealTimeImport:
@@ -52,4 +59,8 @@ class RealTimeImport:
         return [
             terminate_not_full_completion_cases,
             get_user_data,
+            get_exam_data,
+            check_service_availability,
+            import_candidate_demographics,
+            import_exam_authorization,
         ]

--- a/eox_nelp/pearson_vue/rti_backend.py
+++ b/eox_nelp/pearson_vue/rti_backend.py
@@ -5,7 +5,7 @@ and executing various processes related to rti.
 Classes:
     RealTimeImport: Class for managing RTI operations and executing the pipeline.
 """
-from eox_nelp.pearson_vue.pipeline import check_completion_metadata, get_user_data
+from eox_nelp.pearson_vue.pipeline import get_user_data, terminate_not_full_completion_cases
 
 
 class RealTimeImport:
@@ -50,6 +50,6 @@ class RealTimeImport:
         Returns the RTI pipeline, which is a list of functions to be executed.
         """
         return [
-            check_completion_metadata,
+            terminate_not_full_completion_cases,
             get_user_data,
         ]

--- a/eox_nelp/pearson_vue/tests/test_pipeline.py
+++ b/eox_nelp/pearson_vue/tests/test_pipeline.py
@@ -14,12 +14,12 @@ from django_countries.fields import Country
 from eox_nelp.edxapp_wrapper.student import anonymous_id_for_user
 from eox_nelp.pearson_vue.constants import PAYLOAD_CDD, PAYLOAD_EAD, PAYLOAD_PING_DATABASE
 from eox_nelp.pearson_vue.pipeline import (
-    check_completion_metadata,
     check_service_availability,
     get_exam_data,
     get_user_data,
     import_candidate_demographics,
     import_exam_authorization,
+    terminate_not_full_completion_cases,
 )
 
 User = get_user_model()
@@ -27,7 +27,7 @@ User = get_user_model()
 
 class TestCheckCompletionAndGradedMetadata(unittest.TestCase):
     """
-    Unit tests for the check_completion_metadata function.
+    Unit tests for the terminate_not_full_completion_cases function.
     """
 
     def setUp(self):
@@ -47,7 +47,7 @@ class TestCheckCompletionAndGradedMetadata(unittest.TestCase):
         """
         pipeline_kwargs = {"is_passing": True}
 
-        result = check_completion_metadata(self.user_id, self.course_id, **pipeline_kwargs)
+        result = terminate_not_full_completion_cases(self.user_id, self.course_id, **pipeline_kwargs)
 
         get_completed_and_graded_mock.assert_not_called()
         self.assertIsNone(result)
@@ -65,15 +65,14 @@ class TestCheckCompletionAndGradedMetadata(unittest.TestCase):
             "is_complete": True,
             "is_graded": False,
         }
-        expected_output = get_complete_and_graded_output
         get_completed_and_graded_mock.return_value = (
             get_complete_and_graded_output["is_complete"],
             get_complete_and_graded_output["is_graded"],
         )
 
-        result = check_completion_metadata(self.user_id, self.course_id, **pipeline_kwargs)
+        result = terminate_not_full_completion_cases(self.user_id, self.course_id, **pipeline_kwargs)
 
-        self.assertDictEqual(expected_output, result)
+        self.assertIsNone(result)
 
     @patch("eox_nelp.pearson_vue.pipeline.get_completed_and_graded")
     def test_check_not_complete_not_graded(self, get_completed_and_graded_mock):
@@ -95,7 +94,7 @@ class TestCheckCompletionAndGradedMetadata(unittest.TestCase):
             get_complete_and_graded_output["is_graded"],
         )
 
-        result = check_completion_metadata(self.user_id, self.course_id, **pipeline_kwargs)
+        result = terminate_not_full_completion_cases(self.user_id, self.course_id, **pipeline_kwargs)
 
         self.assertDictEqual(expected_output, result)
 
@@ -119,7 +118,7 @@ class TestCheckCompletionAndGradedMetadata(unittest.TestCase):
             get_complete_and_graded_output["is_graded"],
         )
 
-        result = check_completion_metadata(self.user_id, self.course_id, **pipeline_kwargs)
+        result = terminate_not_full_completion_cases(self.user_id, self.course_id, **pipeline_kwargs)
 
         self.assertDictEqual(expected_output, result)
 
@@ -143,7 +142,7 @@ class TestCheckCompletionAndGradedMetadata(unittest.TestCase):
             get_complete_and_graded_output["is_graded"],
         )
 
-        result = check_completion_metadata(self.user_id, self.course_id, **pipeline_kwargs)
+        result = terminate_not_full_completion_cases(self.user_id, self.course_id, **pipeline_kwargs)
 
         self.assertDictEqual(expected_output, result)
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

feat: configure receiver and pipe for completion and grade passed course.

Created 2 receivers one for block_completion post_save signal, and the other  `COURSE_GRADE_NOW_PASSED` signal.
Each one has a setting to manage.
- `PEARSON_RTI_ACTIVATE_COMPLETION_GATE`
- `PEARSON_RTI_ACTIVATE_GRADED_GATE`

Then is a pipeline(`handle_course_completion_status`) that analyzes whether to continue the pipeline in completion cases or not. This would be the first on the list.
The pipeline has 3 behaviors depending on the case:
  - is_passing is true means the course is graded(passed) and doesn't need this pipe validation.
    The pipeline continues without changes.
  - is_complete=True and is_graded=False pipeline should continue with uploaded metadata
          (completed courses and not graded).
  - Otherwise, the pipeline will stop, for graded-courses the `COURSE_GRADE_NOW_PASSED` signal would act with (`is_passing`).
## Testing instructions

Check test of the pipeline.

## Additional information



## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
