### PR TITLE
feat: extract validation otp from user-profile logic

### DIFF
--- a/eox_nelp/one_time_password/api/v1/urls.py
+++ b/eox_nelp/one_time_password/api/v1/urls.py
@@ -1,10 +1,11 @@
 """eox_nelp one_time_password api v1 urls"""
 from django.urls import path
 
-from eox_nelp.one_time_password.api.v1.views import generate_otp
+from eox_nelp.one_time_password.api.v1.views import generate_otp, validate
 
 app_name = "eox_nelp"  # pylint: disable=invalid-name
 
 urlpatterns = [
     path("generate/", generate_otp, name="generate-otp"),
+    path("validate/", validate, name="validate-otp"),
 ]

--- a/eox_nelp/one_time_password/api/v1/views.py
+++ b/eox_nelp/one_time_password/api/v1/views.py
@@ -16,6 +16,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from eox_nelp.one_time_password.generators import generate_otp_code
+from eox_nelp.one_time_password.view_decorators import validate_otp
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ def generate_otp(request):
     """ View for generate OTP.
     ## Usage
 
-    ### **POST** /eox-nelp/api/one-time-password/v1/generate-otp/
+    ### **POST** /eox-nelp/api/one-time-password/v1/generate/
 
     request example data:
     ``` json
@@ -61,3 +62,32 @@ def generate_otp(request):
     cache.set(user_otp_key, otp, timeout=getattr(settings, "PHONE_VALIDATION_OTP_TIMEOUT", 600))
 
     return Response({"message": "Success generate-otp!"}, status=status.HTTP_201_CREATED)
+
+
+@api_view(["POST"])
+@authentication_classes((
+    SessionAuthenticationAllowInactiveUser,
+))
+@permission_classes((IsAuthenticated,))
+@validate_otp
+def validate(request):  # pylint: disable=unused-argument
+    """ View for generate OTP.
+    ## Usage
+
+    ### **POST** /eox-nelp/api/one-time-password/v1/validate/
+
+    request example data:
+    ``` json
+    {
+        "phone_number": 3213123123,
+        "one_time_password": "234fasds"
+    }
+    ```
+    **POST Response Values**
+    ``` json
+    {
+        "message": "Valid OTP code"
+    }
+    ```
+    """
+    return Response({"message": "Valid OTP code"}, status=status.HTTP_200_OK)

--- a/eox_nelp/one_time_password/view_decorators.py
+++ b/eox_nelp/one_time_password/view_decorators.py
@@ -1,0 +1,62 @@
+"""
+This module contains custom decorators for use in Django views.
+
+Decorators:
+    validate_otp(func): A decorator to validate the one-time password (OTP) for a user.
+"""
+import functools
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+from django.http import HttpResponseForbidden, JsonResponse
+from rest_framework import status
+
+logger = logging.getLogger(__name__)
+
+
+def validate_otp(func):
+    """
+    Decorator to validate the one-time password (OTP) for a user.
+
+    This decorator checks if OTP validation is enabled in the settings. If enabled, it validates the OTP provided
+    in the request data against the cached OTP for the user. If the validation fails, it returns an appropriate
+    HTTP response. If the validation is successful or if OTP validation is disabled, it calls the wrapped function.
+
+    Args:
+        func (function): The function to be decorated.
+
+    Returns:
+        function: The wrapped function with OTP validation logic applied.
+
+    The wrapped function expects the request data to contain the following fields:
+        - phone_number (str): The user's phone number.
+        - one_time_password (str): The OTP provided by the user.
+
+    HTTP Responses:
+        - 400 Bad Request: If the phone_number or one_time_password is missing from the request data.
+        - 403 Forbidden: If the provided OTP does not match the cached OTP for the user.
+    """
+    @functools.wraps(func)
+    def wrapper(request):
+        if getattr(settings, "ENABLE_OTP_VALIDATION", True):
+            user_phone_number = request.data.get("phone_number", None)
+            proposed_user_otp = request.data.get("one_time_password", None)
+
+            if not user_phone_number or not proposed_user_otp:
+                return JsonResponse(
+                    data={"detail": "missing phone_number or one_time_password in data."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            user_otp_key = f"{request.user.username}-{user_phone_number}"
+            logger.info("validating otp for %s*****", user_otp_key[:-5])
+
+            if not proposed_user_otp == cache.get(user_otp_key):
+                return HttpResponseForbidden(reason="Forbidden - wrong code")
+
+            cache.delete(user_otp_key)
+
+        return func(request)
+
+    return wrapper

--- a/eox_nelp/user_profile/api/v1/tests/test_views.py
+++ b/eox_nelp/user_profile/api/v1/tests/test_views.py
@@ -4,16 +4,15 @@ Classes:
     UpdateUserDataTestCase: Class to test update_user_data view
 """
 
-from ddt import data, ddt
+from ddt import ddt
 from django.contrib.auth import get_user_model
-from django.core.cache import cache
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from eox_nelp.edxapp_wrapper.user_api import accounts, errors
 from eox_nelp.tests.mixins import POSTAuthenticatedTestMixin
-from eox_nelp.user_profile.api.v1 import views
 
 User = get_user_model()
 
@@ -28,115 +27,59 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
         accounts.reset_mock()
         accounts.api.update_account_settings.side_effect = None
 
-    @data({}, {"not_phone_number": 3123123123}, {"not_one_time_password": 12345678, "phone_number": 3123123123})
-    def test_validate_otp_without_right_payload(self, wrong_payload):
+    @override_settings(ENABLE_OTP_VALIDATION=False)
+    def test_update_fields_successfully(self):
         """
-        Test  the post request to validate otp is not running due missing keys in the payload sent.
+        Test that the request completes its execution successfully.
+
         Expected behavior:
-            - Check the response say is missing some keys.
-            - Status code 400.
-            - Check that update_account_settings method has not been called.
-        """
-        url_endpoint = reverse(self.reverse_viewname)
-
-        response = self.client.post(url_endpoint, wrong_payload, format="json")
-
-        self.assertDictEqual(response.json(), {"detail": "missing phone_number or one_time_password in data."})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        accounts.api.update_account_settings.assert_not_called()
-
-    def test_validate_otp_without_right_validation_code(self):
-        """
-        Test  the post request to validate otp with wrong validation code.
-        Expected behavior:
-            - Check logging validation msg
-            - Status code 403.
-            - Check that update_account_settings method has not been called.
-        """
-        correct_otp = "correct17"
-        payload = {"phone_number": 3219990000, "one_time_password": "password"}
-        url_endpoint = reverse(self.reverse_viewname)
-        user_otp_key = f"{self.user.username}-{payload['phone_number']}"
-        cache.set(user_otp_key, correct_otp, timeout=600)
-
-        with self.assertLogs(views.__name__, level="INFO") as logs:
-            response = self.client.post(url_endpoint, payload, format="json")
-
-        self.assertEqual(logs.output, [
-            f"INFO:{views.__name__}:validating otp for {user_otp_key[:-5]}*****"
-        ])
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        accounts.api.update_account_settings.assert_not_called()
-
-    def test_validate_otp_right_validation_code(self):
-        """
-        Test  the post  request to validate otp with good reqs.
-        Expected behavior:
-            - Check loggin validation msg
-            - Check the response say success validate-otp.
+            - Check the response says that the field has been updated.
             - Status code 200.
             - Check that update_account_settings method has called once.
         """
-        correct_otp = "correct26"
-        payload = {"phone_number": 3219990000, "one_time_password": correct_otp}
+        payload = {"phone_number": 3219990000, "one_time_password": "correct26"}
         url_endpoint = reverse(self.reverse_viewname)
-        user_otp_key = f"{self.user.username}-{payload['phone_number']}"
-        cache.set(user_otp_key, correct_otp, timeout=600)
 
-        with self.assertLogs(views.__name__, level="INFO") as logs:
-            response = self.client.post(url_endpoint, payload, format="json")
+        response = self.client.post(url_endpoint, payload, format="json")
 
-        self.assertEqual(logs.output, [
-            f"INFO:{views.__name__}:validating otp for {user_otp_key[:-5]}*****"
-        ])
         self.assertDictEqual(response.json(), {"message": "User's fields has been updated successfully"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         accounts.api.update_account_settings.assert_called_once_with(self.user, payload)
 
+    @override_settings(ENABLE_OTP_VALIDATION=False)
     def test_account_validation_error(self):
         """
         Test that a bad request is returned when an AccountValidationError is raised.
 
         Expected behavior:
-            - Check logging validation msg
             - Check the response contains fields_errors.
             - Status code 400.
             - Check that update_account_settings method has called once.
         """
-        correct_otp = "correct26"
-        payload = {"phone_number": 3219990000, "one_time_password": correct_otp}
+        payload = {"phone_number": 3219990000, "one_time_password": "correct26"}
         url_endpoint = reverse(self.reverse_viewname)
-        user_otp_key = f"{self.user.username}-{payload['phone_number']}"
-        cache.set(user_otp_key, correct_otp, timeout=600)
         accounts.api.update_account_settings.side_effect = errors.AccountValidationError(
             field_errors="Invalid phone number",
         )
 
-        with self.assertLogs(views.__name__, level="INFO") as logs:
-            response = self.client.post(url_endpoint, payload, format="json")
+        response = self.client.post(url_endpoint, payload, format="json")
 
-        self.assertEqual(logs.output, [
-            f"INFO:{views.__name__}:validating otp for {user_otp_key[:-5]}*****"
-        ])
         self.assertDictEqual(response.json(), {"field_errors": "Invalid phone number"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         accounts.api.update_account_settings.assert_called_once_with(self.user, payload)
 
+    @override_settings(ENABLE_OTP_VALIDATION=False)
     def test_account_update_error(self):
         """
         Test that a bad request is returned when an AccountUpdateError is raised.
 
         Expected behavior:
-            - Check logging validation msg
             - Check the response contains developer and user message.
             - Status code 400.
             - Check that update_account_settings method has called once.
         """
-        correct_otp = "correct26"
-        payload = {"phone_number": 3219990000, "one_time_password": correct_otp}
+        payload = {"phone_number": 3219990000, "one_time_password": "correct26"}
         url_endpoint = reverse(self.reverse_viewname)
-        user_otp_key = f"{self.user.username}-{payload['phone_number']}"
-        cache.set(user_otp_key, correct_otp, timeout=600)
         expected_response = {
             "developer_message": "The testing method failed",
             "user_message": "You user wasn't updated",
@@ -145,12 +88,8 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
             **expected_response,
         )
 
-        with self.assertLogs(views.__name__, level="INFO") as logs:
-            response = self.client.post(url_endpoint, payload, format="json")
+        response = self.client.post(url_endpoint, payload, format="json")
 
-        self.assertEqual(logs.output, [
-            f"INFO:{views.__name__}:validating otp for {user_otp_key[:-5]}*****"
-        ])
         self.assertDictEqual(response.json(), expected_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         accounts.api.update_account_settings.assert_called_once_with(self.user, payload)


### PR DESCRIPTION

## Description

This removes the OTP validation logic from the user-profile view and creates a new view that implements a new decorator that executes the OTP validation

## Testing instructions
This doesn't modify the current behavior of update_user_data, so the first step is to verify that the implementation has not been modify

Make a POST request to `/eox-nelp/api/one-time-password/v1/validate/ `with the right  data, the code could be generated with the current endpoint `/eox-nelp/api/one-time-password/v1/generate/`

### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
