### PR TITLE
feat: set default phone number

### DIFF
--- a/eox_nelp/one_time_password/api/v1/views.py
+++ b/eox_nelp/one_time_password/api/v1/views.py
@@ -45,7 +45,7 @@ def generate_otp(request):
     }
     ```
     """
-    user_phone_number = request.data.get("phone_number", None)
+    user_phone_number = request.data.get("phone_number", request.user.profile.phone_number)
 
     if not user_phone_number:
         return JsonResponse(

--- a/eox_nelp/one_time_password/view_decorators.py
+++ b/eox_nelp/one_time_password/view_decorators.py
@@ -40,7 +40,7 @@ def validate_otp(func):
     @functools.wraps(func)
     def wrapper(request):
         if getattr(settings, "ENABLE_OTP_VALIDATION", True):
-            user_phone_number = request.data.get("phone_number", None)
+            user_phone_number = request.data.get("phone_number", request.user.profile.phone_number)
             proposed_user_otp = request.data.get("one_time_password", None)
 
             if not user_phone_number or not proposed_user_otp:

--- a/eox_nelp/tests/mixins.py
+++ b/eox_nelp/tests/mixins.py
@@ -7,6 +7,7 @@ Classes:
 from ddt import data, ddt
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+from mock import Mock
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -26,6 +27,7 @@ class POSTAuthenticatedTestMixin:
         self.client = APIClient()
         self.user, _ = User.objects.get_or_create(username="vader")
         self.client.force_authenticate(self.user)
+        setattr(self.user, "profile", Mock(phone_number=None))
 
     @data(*NOT_ALLOWED_HTTP_METHODS)
     def test_method_not_allowed(self, method_name):


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This makes optional the phone_number API parameter, by taking as default option the database information

## Testing instructions
1. Set the user phone number
2. Make a POST request with an empty body `/eox-nelp/api/one-time-password/v1/generate/`
3. Check logs and response

![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/7ba6599c-693e-4f6f-8cc1-2d46f09bf24c)
![image](https://github.com/eduNEXT/eox-nelp/assets/36200299/514d6786-f5ca-4a06-96f6-127c7e2ac4d6)




### Before

### After

