### PR TITLE
feat: support missing user field in update_user_data API view

### DIFF
--- a/eox_nelp/user_profile/api/v1/tests/test_views.py
+++ b/eox_nelp/user_profile/api/v1/tests/test_views.py
@@ -93,3 +93,30 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
         self.assertDictEqual(response.json(), expected_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         accounts.api.update_account_settings.assert_called_once_with(self.user, payload)
+
+    @override_settings(ENABLE_OTP_VALIDATION=False, EXTRA_ACCOUNT_USER_FIELDS=["first_name", "last_name"])
+    def test_account_update_extra_fields(self):
+        """
+        Test that extra account user fields has been set.
+
+        Expected behavior:
+            - Check the response says that the field has been updated.
+            - Status code 200.
+            - Check that update_account_settings method has called once.
+            - Check that user first_name has been updated.
+            - Check that user last_name has been updated.
+        """
+        payload = {
+            "first_name": "Anakin",
+            "last_name": "Skywalker",
+            "one_time_password": "correct26",
+        }
+        url_endpoint = reverse(self.reverse_viewname)
+
+        response = self.client.post(url_endpoint, payload, format="json")
+
+        self.assertDictEqual(response.json(), {"message": "User's fields has been updated successfully"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        accounts.api.update_account_settings.assert_called_once_with(self.user, payload)
+        self.assertEqual(self.user.first_name, payload["first_name"])
+        self.assertEqual(self.user.last_name, payload["last_name"])


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description
support missing user field in update_user_data API view


## Testing instructions
1. Add settings e,g
```python
EXTRA_ACCOUNT_USER_FIELDS = (
    "first_name",
    "last_name",
)
```
2. Go to /eox-nelp/api/user-profile/v1/update-user-data/
3. Send the field and check


![ausf](https://github.com/eduNEXT/eox-nelp/assets/36200299/658d2e7b-c8e9-42ac-833f-42b55fbab565)

### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
