### PR TITLE
refactor: split pipeline steps for cdd ead requests

### DIFF
--- a/eox_nelp/pearson_vue/rti_backend.py
+++ b/eox_nelp/pearson_vue/rti_backend.py
@@ -6,6 +6,8 @@ Classes:
     RealTimeImport: Class for managing RTI operations and executing the pipeline.
 """
 from eox_nelp.pearson_vue.pipeline import (
+    build_cdd_request,
+    build_ead_request,
     check_service_availability,
     get_exam_data,
     get_user_data,
@@ -60,6 +62,8 @@ class RealTimeImport:
             handle_course_completion_status,
             get_user_data,
             get_exam_data,
+            build_cdd_request,
+            build_ead_request,
             check_service_availability,
             import_candidate_demographics,
             import_exam_authorization,
@@ -75,6 +79,7 @@ class ExamAuthorizationDataImport(RealTimeImport):
         return [
             get_user_data,
             get_exam_data,
+            build_ead_request,
             check_service_availability,
             import_exam_authorization,
         ]
@@ -88,6 +93,7 @@ class CandidateDemographicsDataImport(RealTimeImport):
         """
         return [
             get_user_data,
+            build_cdd_request,
             check_service_availability,
             import_candidate_demographics,
         ]


### PR DESCRIPTION
# Description
This adds 2 pipeline steps independent to build
cdd_request and ead_request dicts.

<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

