### PR TITLE
feat: add cdd task to user updated profile api

### DIFF
--- a/eox_nelp/user_profile/api/v1/tests/test_views.py
+++ b/eox_nelp/user_profile/api/v1/tests/test_views.py
@@ -4,6 +4,8 @@ Classes:
     UpdateUserDataTestCase: Class to test update_user_data view
 """
 
+from unittest.mock import patch
+
 from ddt import ddt
 from django.contrib.auth import get_user_model
 from django.test import override_settings
@@ -28,7 +30,8 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
         accounts.api.update_account_settings.side_effect = None
 
     @override_settings(ENABLE_OTP_VALIDATION=False)
-    def test_update_fields_successfully(self):
+    @patch("eox_nelp.user_profile.api.v1.views.cdd_task")
+    def test_update_fields_successfully(self, cdd_task_mock):
         """
         Test that the request completes its execution successfully.
 
@@ -36,6 +39,7 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
             - Check the response says that the field has been updated.
             - Status code 200.
             - Check that update_account_settings method has called once.
+            - Check cdd_task async task is called user.id
         """
         payload = {"phone_number": 3219990000, "one_time_password": "correct26"}
         url_endpoint = reverse(self.reverse_viewname)
@@ -45,9 +49,11 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
         self.assertDictEqual(response.json(), {"message": "User's fields has been updated successfully"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         accounts.api.update_account_settings.assert_called_once_with(self.user, payload)
+        cdd_task_mock.delay.assert_called_with(user_id=self.user.id)
 
     @override_settings(ENABLE_OTP_VALIDATION=False)
-    def test_account_validation_error(self):
+    @patch("eox_nelp.user_profile.api.v1.views.cdd_task")
+    def test_account_validation_error(self, cdd_task_mock):
         """
         Test that a bad request is returned when an AccountValidationError is raised.
 
@@ -55,6 +61,7 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
             - Check the response contains fields_errors.
             - Status code 400.
             - Check that update_account_settings method has called once.
+            - Check cdd_task async is not called.
         """
         payload = {"phone_number": 3219990000, "one_time_password": "correct26"}
         url_endpoint = reverse(self.reverse_viewname)
@@ -67,9 +74,11 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
         self.assertDictEqual(response.json(), {"field_errors": "Invalid phone number"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         accounts.api.update_account_settings.assert_called_once_with(self.user, payload)
+        cdd_task_mock.delay.assert_not_called()
 
     @override_settings(ENABLE_OTP_VALIDATION=False)
-    def test_account_update_error(self):
+    @patch("eox_nelp.user_profile.api.v1.views.cdd_task")
+    def test_account_update_error(self, cdd_task_mock):
         """
         Test that a bad request is returned when an AccountUpdateError is raised.
 
@@ -77,6 +86,7 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
             - Check the response contains developer and user message.
             - Status code 400.
             - Check that update_account_settings method has called once.
+            - Check cdd_task async is not called.
         """
         payload = {"phone_number": 3219990000, "one_time_password": "correct26"}
         url_endpoint = reverse(self.reverse_viewname)
@@ -93,9 +103,11 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
         self.assertDictEqual(response.json(), expected_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         accounts.api.update_account_settings.assert_called_once_with(self.user, payload)
+        cdd_task_mock.delay.assert_not_called()
 
     @override_settings(ENABLE_OTP_VALIDATION=False, EXTRA_ACCOUNT_USER_FIELDS=["first_name", "last_name"])
-    def test_account_update_extra_fields(self):
+    @patch("eox_nelp.user_profile.api.v1.views.cdd_task")
+    def test_account_update_extra_fields(self, cdd_task_mock):
         """
         Test that extra account user fields has been set.
 
@@ -105,6 +117,7 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
             - Check that update_account_settings method has called once.
             - Check that user first_name has been updated.
             - Check that user last_name has been updated.
+            - Check cdd_task async task is called with user.id
         """
         payload = {
             "first_name": "Anakin",
@@ -120,3 +133,4 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
         accounts.api.update_account_settings.assert_called_once_with(self.user, payload)
         self.assertEqual(self.user.first_name, payload["first_name"])
         self.assertEqual(self.user.last_name, payload["last_name"])
+        cdd_task_mock.delay.assert_called_with(user_id=self.user.id)

--- a/eox_nelp/user_profile/api/v1/tests/test_views.py
+++ b/eox_nelp/user_profile/api/v1/tests/test_views.py
@@ -30,8 +30,8 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
         accounts.api.update_account_settings.side_effect = None
 
     @override_settings(
-            ENABLE_OTP_VALIDATION=False,
-            PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True,
+        ENABLE_OTP_VALIDATION=False,
+        PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True,
     )
     @patch("eox_nelp.user_profile.api.v1.views.cdd_task")
     def test_update_fields_successfully(self, cdd_task_mock):

--- a/eox_nelp/user_profile/api/v1/tests/test_views.py
+++ b/eox_nelp/user_profile/api/v1/tests/test_views.py
@@ -29,7 +29,10 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
         accounts.reset_mock()
         accounts.api.update_account_settings.side_effect = None
 
-    @override_settings(ENABLE_OTP_VALIDATION=False)
+    @override_settings(
+            ENABLE_OTP_VALIDATION=False,
+            PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True,
+    )
     @patch("eox_nelp.user_profile.api.v1.views.cdd_task")
     def test_update_fields_successfully(self, cdd_task_mock):
         """
@@ -105,7 +108,11 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
         accounts.api.update_account_settings.assert_called_once_with(self.user, payload)
         cdd_task_mock.delay.assert_not_called()
 
-    @override_settings(ENABLE_OTP_VALIDATION=False, EXTRA_ACCOUNT_USER_FIELDS=["first_name", "last_name"])
+    @override_settings(
+        ENABLE_OTP_VALIDATION=False,
+        EXTRA_ACCOUNT_USER_FIELDS=["first_name", "last_name"],
+        PEARSON_RTI_ACTIVATE_GRADED_GATE=True,
+    )
     @patch("eox_nelp.user_profile.api.v1.views.cdd_task")
     def test_account_update_extra_fields(self, cdd_task_mock):
         """

--- a/eox_nelp/user_profile/api/v1/views.py
+++ b/eox_nelp/user_profile/api/v1/views.py
@@ -75,7 +75,10 @@ def update_user_data(request):
             },
             status=status.HTTP_400_BAD_REQUEST
         )
-
-    cdd_task.delay(user_id=request.user.id)  # Send cdd request with user updated.
+    if (
+        getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False) or
+        getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False)
+    ):
+        cdd_task.delay(user_id=request.user.id)  # Send cdd request with user updated.
 
     return Response({"message": "User's fields has been updated successfully"}, status=status.HTTP_200_OK)

--- a/eox_nelp/user_profile/api/v1/views.py
+++ b/eox_nelp/user_profile/api/v1/views.py
@@ -76,8 +76,8 @@ def update_user_data(request):
             status=status.HTTP_400_BAD_REQUEST
         )
     if (
-        getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False) or
-        getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False)
+        getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False)
+        or getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False)
     ):
         cdd_task.delay(user_id=request.user.id)  # Send cdd request with user updated.
 

--- a/eox_nelp/user_profile/api/v1/views.py
+++ b/eox_nelp/user_profile/api/v1/views.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 
 from eox_nelp.edxapp_wrapper.user_api import accounts, errors
 from eox_nelp.one_time_password.view_decorators import validate_otp
+from eox_nelp.pearson_vue.tasks import cdd_task
 
 logger = logging.getLogger(__name__)
 
@@ -74,5 +75,7 @@ def update_user_data(request):
             },
             status=status.HTTP_400_BAD_REQUEST
         )
+
+    cdd_task.delay(user_id=request.user.id)  # Send cdd request with user updated.
 
     return Response({"message": "User's fields has been updated successfully"}, status=status.HTTP_200_OK)


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

[feat: add cdd task to user updated profile api](https://github.com/eduNEXT/eox-nelp/commit/3a42dd98d955d874b70831181b7f4af2617f1d15)



## Testing instructions
### After
Update your profile using profile API or using bragi modal.
Check the cdd_task is triggered.
![Peek 2024-06-20 15-45](https://github.com/eduNEXT/eox-nelp/assets/51926076/af22d9d8-498b-4b5f-aacf-0f34cfd53b6f)

Check audit record was sent.
![2024-06-20_15-52](https://github.com/eduNEXT/eox-nelp/assets/51926076/4db486e9-c8f2-4390-a5aa-789e390fc9e5)




## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
