### PR TITLE
And/generate certificate based on rten request

### DIFF
--- a/eox_nelp/edxapp_wrapper/backends/certificates_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/certificates_m_v1.py
@@ -18,3 +18,13 @@ def get_generated_certificates_admin():
         return certificates.admin.GeneratedCertificateAdmin
 
     return admin.ModelAdmin
+
+
+def get_generate_course_certificate_method():
+    """Allow to get the generate_course_certificate method.
+    https://github.com/nelc/edx-platform/blob/open-release/palm.nelp/lms/djangoapps/certificates/generation.py#L20
+
+    Returns:
+        generate_course_certificate method.
+    """
+    return certificates.generation.generate_course_certificate

--- a/eox_nelp/edxapp_wrapper/certificates.py
+++ b/eox_nelp/edxapp_wrapper/certificates.py
@@ -12,3 +12,4 @@ from django.conf import settings
 backend = import_module(settings.EOX_NELP_CERTIFICATES_BACKEND)
 
 GeneratedCertificateAdmin = backend.get_generated_certificates_admin()
+generate_course_certificate = backend.get_generate_course_certificate_method()

--- a/eox_nelp/edxapp_wrapper/test_backends/certificates_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/certificates_m_v1.py
@@ -47,3 +47,12 @@ def get_generated_certificate():
     return create_test_model(
         "GeneratedCertificate", "eox_nelp", __package__, generated_certificate_fields
     )
+
+
+def get_generate_course_certificate_method():
+    """Return generate_course_certificate mock method.
+
+    Returns:
+        Mock instance.
+    """
+    return Mock()

--- a/eox_nelp/pearson_vue/exceptions.py
+++ b/eox_nelp/pearson_vue/exceptions.py
@@ -96,3 +96,8 @@ class PearsonImportError(PearsonBaseError):
     Error related with a failure response from Pearson Vue site.
     """
     exception_type = "import-error"
+
+
+class PearsonTypeError(PearsonBaseError):
+    """Pearson type error class"""
+    exception_type = "type-error"

--- a/eox_nelp/pearson_vue/pipeline.py
+++ b/eox_nelp/pearson_vue/pipeline.py
@@ -32,6 +32,7 @@ from eox_nelp.pearson_vue.exceptions import (
     PearsonBaseError,
     PearsonImportError,
     PearsonKeyError,
+    PearsonTypeError,
     PearsonValidationError,
 )
 from eox_nelp.pearson_vue.utils import generate_client_authorization_id, update_xml_with_dict
@@ -512,22 +513,26 @@ def extract_result_notification_data(request_data, **kwargs):  # pylint: disable
         dict: A dictionary containing extracted data including exam result, client authorization ID,
               enrollment ID, anonymous user model ID, and anonymous user ID.
     """
-    client_authorization_id = request_data["authorization"]["clientAuthorizationID"]
-    client_authorization_elements = client_authorization_id.split("-")
-    enrollment_id = client_authorization_elements[0]
-    anonymous_user_model_id = client_authorization_elements[1]
-    anonymous_user_id = request_data["clientCandidateID"].replace("NELC", "")
 
-    return {
-        "exam_result": request_data["exams"]["exam"][0]["examResult"],
-        "client_authorization_id": client_authorization_id,
-        "enrollment_id": enrollment_id,
-        "anonymous_user_model_id": anonymous_user_model_id,
-        "anonymous_user_id": anonymous_user_id,
-    }
+    try:
+        client_authorization_id = request_data["authorization"]["clientAuthorizationID"]
+        client_authorization_elements = client_authorization_id.split("-")
+        enrollment_id = client_authorization_elements[0]
+        anonymous_user_model_id = client_authorization_elements[1]
+        anonymous_user_id = request_data["clientCandidateID"].replace("NELC", "")
+
+        return {
+            "exam_result": request_data["exams"]["exam"][0]["examResult"],
+            "client_authorization_id": client_authorization_id,
+            "enrollment_id": enrollment_id,
+            "anonymous_user_model_id": anonymous_user_model_id,
+            "anonymous_user_id": anonymous_user_id,
+        }
+    except (KeyError, IndexError) as exc:
+        raise PearsonKeyError(exception_reason=str(exc), pipe_frame=inspect.currentframe()) from exc
 
 
-def generate_external_certificate(enrollment, exam_result, **kwargs):  # pylint: disable=unused-argument
+def generate_external_certificate(enrollment=None, exam_result=None, **kwargs):  # pylint: disable=unused-argument
     """
     Generates an external certificate if the exam result meets the passing criteria.
 
@@ -536,6 +541,12 @@ def generate_external_certificate(enrollment, exam_result, **kwargs):  # pylint:
         exam_result (dict): The dictionary containing the exam result data.
         **kwargs: Additional keyword arguments.
     """
+    if not enrollment or not exam_result:
+        raise PearsonTypeError(
+            exception_reason="Method generate_external_certificate has failed due to a missing variable",
+            pipe_frame=inspect.currentframe()
+        )
+
     passing_score = float(exam_result.get("passingScore", 1))
     score = float(exam_result.get("score", 0))
 
@@ -582,7 +593,7 @@ def get_enrollment_from_anonymous_user_id(
     return {}
 
 
-def get_enrollment_from_id(enrollment_id, **kwargs):  # pylint: disable=unused-argument
+def get_enrollment_from_id(enrollment_id, enrollment=None, **kwargs):  # pylint: disable=unused-argument
     """
     Retrieves enrollment information based on the enrollment ID.
 
@@ -593,9 +604,12 @@ def get_enrollment_from_id(enrollment_id, **kwargs):  # pylint: disable=unused-a
     Returns:
         dict: A dictionary containing the enrollment object if found, otherwise an empty dictionary.
     """
-    try:
-        return {
-            "enrollment": CourseEnrollment.objects.get(id=enrollment_id)
-        }
-    except ObjectDoesNotExist:
-        return {}
+    if not enrollment:
+        try:
+            return {
+                "enrollment": CourseEnrollment.objects.get(id=enrollment_id)
+            }
+        except ObjectDoesNotExist:
+            pass
+
+    return {}

--- a/eox_nelp/pearson_vue/pipeline.py
+++ b/eox_nelp/pearson_vue/pipeline.py
@@ -18,11 +18,13 @@ import logging
 import phonenumbers
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from pydantic import ValidationError
 
 from eox_nelp.api_clients.pearson_rti import PearsonRTIApiClient
-from eox_nelp.edxapp_wrapper.student import anonymous_id_for_user
+from eox_nelp.edxapp_wrapper.certificates import generate_course_certificate
+from eox_nelp.edxapp_wrapper.student import AnonymousUserId, CourseEnrollment, anonymous_id_for_user
 from eox_nelp.pearson_vue.constants import PAYLOAD_CDD, PAYLOAD_EAD, PAYLOAD_PING_DATABASE
 from eox_nelp.pearson_vue.data_classes import CddRequest, EadRequest
 from eox_nelp.pearson_vue.exceptions import (
@@ -496,3 +498,104 @@ def audit_pearson_error(failed_step_pipeline="", exception_dict=None, **kwargs):
         raise_audit_pearson_exception(failed_step_pipeline=failed_step_pipeline, exception_dict=exception_dict)
     except PearsonBaseError as exc:
         logger.error(exc)
+
+
+def extract_result_notification_data(request_data, **kwargs):  # pylint: disable=unused-argument
+    """
+    Extracts result notification data from the request.
+
+    Args:
+        request_data (dict): The dictionary containing the Result Notification request data.
+        **kwargs: Additional keyword arguments.
+
+    Returns:
+        dict: A dictionary containing extracted data including exam result, client authorization ID,
+              enrollment ID, anonymous user model ID, and anonymous user ID.
+    """
+    client_authorization_id = request_data["authorization"]["clientAuthorizationID"]
+    client_authorization_elements = client_authorization_id.split("-")
+    enrollment_id = client_authorization_elements[0]
+    anonymous_user_model_id = client_authorization_elements[1]
+    anonymous_user_id = request_data["clientCandidateID"].replace("NELC", "")
+
+    return {
+        "exam_result": request_data["exams"]["exam"][0]["examResult"],
+        "client_authorization_id": client_authorization_id,
+        "enrollment_id": enrollment_id,
+        "anonymous_user_model_id": anonymous_user_model_id,
+        "anonymous_user_id": anonymous_user_id,
+    }
+
+
+def generate_external_certificate(enrollment, exam_result, **kwargs):  # pylint: disable=unused-argument
+    """
+    Generates an external certificate if the exam result meets the passing criteria.
+
+    Args:
+        enrollment (object): The enrollment object associated with the user and course.
+        exam_result (dict): The dictionary containing the exam result data.
+        **kwargs: Additional keyword arguments.
+    """
+    passing_score = float(exam_result.get("passingScore", 1))
+    score = float(exam_result.get("score", 0))
+
+    if score >= passing_score:
+        generate_course_certificate(
+            enrollment.user,
+            enrollment.course_id,
+            "downloadable",
+            enrollment.mode,
+            score,
+            "batch"
+        )
+
+
+def get_enrollment_from_anonymous_user_id(
+    anonymous_user_model_id,
+    enrollment=None,
+    **kwargs
+):  # pylint: disable=unused-argument
+    """
+    Retrieves enrollment information based on the anonymous user model ID.
+
+    Args:
+        anonymous_user_model_id (str): The ID of the anonymous user model.
+        enrollment (object, optional): An optional enrollment object.
+        **kwargs: Additional keyword arguments.
+
+    Returns:
+        dict: A dictionary containing the enrollment object if found, otherwise an empty dictionary.
+    """
+    if not enrollment:
+        try:
+            anonymous_user_id = AnonymousUserId.objects.get(id=anonymous_user_model_id)
+
+            return {
+                "enrollment": CourseEnrollment.objects.get(
+                    user=anonymous_user_id.user,
+                    course=anonymous_user_id.course_id,
+                )
+            }
+        except ObjectDoesNotExist:
+            pass
+
+    return {}
+
+
+def get_enrollment_from_id(enrollment_id, **kwargs):  # pylint: disable=unused-argument
+    """
+    Retrieves enrollment information based on the enrollment ID.
+
+    Args:
+        enrollment_id (str): The ID of the enrollment.
+        **kwargs: Additional keyword arguments.
+
+    Returns:
+        dict: A dictionary containing the enrollment object if found, otherwise an empty dictionary.
+    """
+    try:
+        return {
+            "enrollment": CourseEnrollment.objects.get(id=enrollment_id)
+        }
+    except ObjectDoesNotExist:
+        return {}

--- a/eox_nelp/pearson_vue/rti_backend.py
+++ b/eox_nelp/pearson_vue/rti_backend.py
@@ -1,9 +1,17 @@
 """
-This module provides the RealTimeImport class, which is responsible for orchestrating the RTI pipeline
-and executing various processes related to rti.
+This module provides classes for managing various backend operations and executing their corresponding pipelines.
 
 Classes:
-    RealTimeImport: Class for managing RTI operations and executing the pipeline.
+    AbstractBackend: Base class for managing backend operations and executing pipelines.
+    ErrorRealTimeImportHandler: Class for managing validation error pipelines and executing
+         the pipeline for data validation.
+    RealTimeImport: Class for managing RTI (Real Time Import) operations and executing the pipeline.
+    ExamAuthorizationDataImport: Class for managing EAD requests (Exam Authorization Data operations)
+        and executing the pipeline.
+    CandidateDemographicsDataImport: Class for managing CDD requests (Candidate Demographics Data operations)
+        and executing the pipeline.
+    ResultNotificationBackend: Class for managing Result Notification operations and executing the
+         corresponding pipeline.
 """
 import importlib
 from abc import ABC, abstractmethod
@@ -14,6 +22,10 @@ from eox_nelp.pearson_vue.pipeline import (
     build_cdd_request,
     build_ead_request,
     check_service_availability,
+    extract_result_notification_data,
+    generate_external_certificate,
+    get_enrollment_from_anonymous_user_id,
+    get_enrollment_from_id,
     get_exam_data,
     get_user_data,
     handle_course_completion_status,
@@ -193,4 +205,34 @@ class CandidateDemographicsDataImport(RealTimeImport):
             validate_cdd_request,
             check_service_availability,
             import_candidate_demographics,
+        ]
+
+
+class ResultNotificationBackend(RealTimeImport):
+    """
+    Class for managing the Result Notification operations and executing the corresponding pipeline.
+
+    This class inherits from RealTimeImport and is responsible for orchestrating the pipeline
+    for handling result notifications, including extracting result notification data,
+    retrieving enrollment information, and generating external certificates.
+    """
+
+    def get_pipeline(self):
+        """
+        Returns the Result Notification pipeline, which is a list of functions to be executed.
+
+        The pipeline includes the following steps:
+        1. `extract_result_notification_data`: Extracts the result notification data.
+        2. `get_enrollment_from_id`: Retrieves the enrollment information based on the given ID.
+        3. `get_enrollment_from_anonymous_user_id`: Retrieves the enrollment information for an anonymous user.
+        4. `generate_external_certificate`: Generates an external certificate based on the enrollment data.
+
+        Returns:
+            list: A list of functions representing the pipeline steps.
+        """
+        return [
+            extract_result_notification_data,
+            get_enrollment_from_id,
+            get_enrollment_from_anonymous_user_id,
+            generate_external_certificate,
         ]

--- a/eox_nelp/pearson_vue/tests/test_pipeline.py
+++ b/eox_nelp/pearson_vue/tests/test_pipeline.py
@@ -1,18 +1,21 @@
 """
 This module contains unit tests for the functions in pipeline.py.
 """
+# pylint: disable=too-many-lines
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
-from ddt import data, ddt
+from ddt import data, ddt, unpack
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
 from django.test import override_settings
 from django.utils import timezone
 from django_countries.fields import Country
 from pydantic.v1.utils import deep_update
 
-from eox_nelp.edxapp_wrapper.student import CourseEnrollment, anonymous_id_for_user
+from eox_nelp.edxapp_wrapper.certificates import generate_course_certificate
+from eox_nelp.edxapp_wrapper.student import AnonymousUserId, CourseEnrollment, anonymous_id_for_user
 from eox_nelp.pearson_vue import pipeline
 from eox_nelp.pearson_vue.constants import PAYLOAD_CDD, PAYLOAD_EAD, PAYLOAD_PING_DATABASE
 from eox_nelp.pearson_vue.exceptions import (
@@ -26,6 +29,10 @@ from eox_nelp.pearson_vue.pipeline import (
     build_cdd_request,
     build_ead_request,
     check_service_availability,
+    extract_result_notification_data,
+    generate_external_certificate,
+    get_enrollment_from_anonymous_user_id,
+    get_enrollment_from_id,
     get_exam_data,
     get_user_data,
     handle_course_completion_status,
@@ -968,3 +975,214 @@ class TestAuditPipeError(unittest.TestCase):
 
         self.assertIsNone(audit_pearson_error(**kwargs))
         logger_mock.error.assert_not_called()
+
+
+@ddt
+class TestExtractResultNotificationData(unittest.TestCase):
+    """
+    Unit tests for the extract_result_notification_data function.
+    """
+
+    def test_extract_result_notification_data_success(self):
+        """Test correct extraction of result notification data.
+
+        Expected behavior:
+            - The returned dictionary contains the correct extracted data.
+        """
+        request_data = {
+            "authorization": {"clientAuthorizationID": "1234-5678"},
+            "clientCandidateID": "NELC9012",
+            "exams": {"exam": [{"examResult": "Pass"}]}
+        }
+        expected_result = {
+            "exam_result": "Pass",
+            "client_authorization_id": "1234-5678",
+            "enrollment_id": "1234",
+            "anonymous_user_model_id": "5678",
+            "anonymous_user_id": "9012",
+        }
+
+        result = extract_result_notification_data(request_data)
+        self.assertEqual(result, expected_result)
+
+    @data(
+        ({"clientCandidateID": "NELC9012", "exams": {"exam": [{"examResult": "Pass"}]}}, KeyError),
+        ({"authorization": {"clientAuthorizationID": "12-58"}, "exams": {"exam": [{"examResult": "Pass"}]}}, KeyError),
+        (
+            {"authorization": {"clientAuthorizationID": "12-5"}, "clientCandidateID": "NELC2", "exams": {"exam": []}},
+            IndexError,
+        ),
+    )
+    @unpack
+    def test_extract_result_notification_data_missing_data(self, request_data, expected_exception):
+        """Test extraction with missing required data fields.
+
+        Expected behavior:
+            - The specified exception is raised due to missing data.
+        """
+        with self.assertRaises(expected_exception):
+            extract_result_notification_data(request_data)
+
+
+@ddt
+class TestGenerateExternalCertificate(unittest.TestCase):
+    """
+    Unit tests for the generate_external_certificate function.
+    """
+
+    def tearDown(self):
+        """Reset the mock after each test."""
+        generate_course_certificate.reset_mock()
+
+    @data(
+        ({'passingScore': '50', 'score': '75'}),
+        ({'passingScore': '0', 'score': '0'}),
+    )
+    def test_generate_external_certificate_success(self, exam_result):
+        """Test generating an external certificate when the score meets the passing criteria.
+
+        Expected behavior:
+            - The generate_course_certificate function is called with the correct arguments.
+        """
+        enrollment = Mock(user='test_user', course_id='test_course', mode='test_mode')
+
+        generate_external_certificate(enrollment, exam_result)
+
+        generate_course_certificate.assert_called_once_with(
+            'test_user', 'test_course', 'downloadable', 'test_mode', float(exam_result["score"]), 'batch'
+        )
+
+    @data(
+        ({'passingScore': '50', 'score': '25'}),
+        ({'passingScore': '100', 'score': '99'}),
+    )
+    def test_generate_external_certificate_various_scores(self, exam_result):
+        """Test generating an external certificate with various scores.
+
+        Expected behavior:
+            - The generate_course_certificate function is not called.
+        """
+        enrollment = Mock(user='test_user', course_id='test_course', mode='test_mode')
+
+        generate_external_certificate(enrollment, exam_result)
+
+        generate_course_certificate.assert_not_called()
+
+
+class TestGetEnrollmentFromAnonymousUserId(unittest.TestCase):
+    """
+    Unit tests for the get_enrollment_from_anonymous_user_id function.
+    """
+
+    def tearDown(self):
+        """
+        Reset the mocked objects after each test.
+        """
+        CourseEnrollment.reset_mock()
+        AnonymousUserId.reset_mock()
+        AnonymousUserId.objects.get.side_effect = None
+
+    def test_get_enrollment_found(self):
+        """
+        Test retrieval of enrollment information when the anonymous user ID is found.
+
+        Expected behavior:
+            - The function returns a dictionary containing the enrollment object.
+            - Verify that the correct calls are made to retrieve the anonymous user and enrollment objects.
+        """
+        anonymous_user_model_id = "valid_id"
+        anonymous_user_id = Mock(user='test_user', course_id='test_course')
+        course_enrollment_obj = Mock()
+        AnonymousUserId.objects.get.return_value = anonymous_user_id
+        CourseEnrollment.objects.get.return_value = course_enrollment_obj
+
+        result = get_enrollment_from_anonymous_user_id(anonymous_user_model_id)
+
+        self.assertEqual(result, {"enrollment": course_enrollment_obj})
+        AnonymousUserId.objects.get.assert_called_once_with(id=anonymous_user_model_id)
+        CourseEnrollment.objects.get.assert_called_once_with(
+            user=anonymous_user_id.user,
+            course=anonymous_user_id.course_id,
+        )
+
+    def test_get_enrollment_not_found(self):
+        """
+        Test behavior when the anonymous user ID is not found.
+
+        Expected behavior:
+            - The function returns an empty dictionary.
+            - Verify that the call to retrieve the anonymous user object raises ObjectDoesNotExist.
+            - Ensure that no attempt is made to retrieve the enrollment object.
+        """
+        anonymous_user_model_id = "invalid_id"
+        AnonymousUserId.objects.get.side_effect = ObjectDoesNotExist
+
+        result = get_enrollment_from_anonymous_user_id(anonymous_user_model_id)
+
+        self.assertEqual(result, {})
+        AnonymousUserId.objects.get.assert_called_once_with(id=anonymous_user_model_id)
+        CourseEnrollment.objects.get.assert_not_called()
+
+    def test_get_enrollment_with_provided_enrollment(self):
+        """
+        Test behavior when an enrollment object is provided as an argument.
+
+        Expected behavior:
+            - The function returns a dictionary containing the provided enrollment object.
+            - Verify that no calls are made to retrieve objects from the database.
+        """
+        # Call the function under test with an enrollment object
+        result = get_enrollment_from_anonymous_user_id("valid_id", enrollment=Mock())
+
+        # Assert the result
+        self.assertEqual(result, {})
+
+        # Verify mock calls
+        AnonymousUserId.objects.get.assert_not_called()
+        CourseEnrollment.objects.get.assert_not_called()
+
+
+class TestGetEnrollmentFromId(unittest.TestCase):
+    """
+    Unit tests for the get_enrollment_from_id function.
+    """
+
+    def tearDown(self):
+        """
+        Reset the mocked objects after each test.
+        """
+        CourseEnrollment.reset_mock()
+        CourseEnrollment.objects.get.side_effect = None
+
+    def test_get_enrollment_found(self):
+        """
+        Test retrieval of enrollment information when the enrollment ID is found.
+
+        Expected behavior:
+            - The function returns a dictionary containing the enrollment object.
+            - Verify that the correct call is made to retrieve the enrollment object.
+        """
+        enrollment_id = "valid_id"
+        enrollment_obj = Mock()
+        CourseEnrollment.objects.get.return_value = enrollment_obj
+
+        result = get_enrollment_from_id(enrollment_id)
+
+        self.assertEqual(result, {"enrollment": enrollment_obj})
+        CourseEnrollment.objects.get.assert_called_once_with(id=enrollment_id)
+
+    def test_get_enrollment_not_found(self):
+        """
+        Test behavior when the enrollment ID is not found.
+
+        Expected behavior:
+            - The function returns an empty dictionary.
+            - Verify that the call to retrieve the enrollment object raises ObjectDoesNotExist.
+        """
+        enrollment_id = "invalid_id"
+        CourseEnrollment.objects.get.side_effect = ObjectDoesNotExist
+
+        result = get_enrollment_from_id(enrollment_id)
+
+        self.assertEqual(result, {})
+        CourseEnrollment.objects.get.assert_called_once_with(id=enrollment_id)

--- a/eox_nelp/pearson_vue/tests/test_rti_backend.py
+++ b/eox_nelp/pearson_vue/tests/test_rti_backend.py
@@ -13,6 +13,7 @@ from eox_nelp.pearson_vue.rti_backend import (
     ErrorRealTimeImportHandler,
     ExamAuthorizationDataImport,
     RealTimeImport,
+    ResultNotificationBackend,
 )
 
 
@@ -237,3 +238,10 @@ class TestErrorRealTimeImportHandler(TestAbstractBackendMixin, unittest.TestCase
     Unit tests for the rti_backend class.
     """
     rti_backend_class = ErrorRealTimeImportHandler
+
+
+class TestResultNotificationBackend(TestRealTimeImport):
+    """
+    Unit tests for the ResultNotificationBackend class.
+    """
+    rti_backend_class = ResultNotificationBackend


### PR DESCRIPTION
## Description

This implements a new backend in the result notification view with new pipeline steps that allow to create a new certificate

## Testing instructions
1. set the setting `ENABLE_CERTIFICATE_PUBLISHER`, this will enable the result notification pipeline and the external certificate publisher,  its not necessary to test the external call so you can use an invalid mode, or if you want to test the external call  set `CERTIFICATE_PUBLISHER_VALID_MODES` with the desired mode
2. Make a postman call with the following data
```json
{
   "eventType":"RESULT_AVAILABLE",
   "eventTime":"?",
   "candidate":{
      "candidateName":{
         "firstName":"Maximo",
         "lastName":"Tercero"
      },
      "email":"?",
      "lastUpdate":"?",
      "vueCandidateID":"?",
      "clientCandidateID":"?"
   },
   "attempt":"$",
   "authorization":{
        "clientAuthorizationID": "1000-3000"
   },
   "exams":{
      "exam":[
         {
            "examDefinition":{
               "examSeriesCode":"?",
               "examLanguageCode":"?",
               "examName":"?",
               "deliveryModel":"?",
               "vueExamVersionId":"?",
               "vueExamRevisionID":"?",
               "clientExamVersionId":"?",
               "examForm":"?",
               "isBetaVersion":"#"
            },
            "examResult":{
               "outcomeType":"?",
               "startTime":"?",
               "timeUsed":"$",
               "passingScore":"0.8",
               "score":"0.832",
               "rawScore":"$",
               "grade":"0.5",
               "correct":"$",
               "incorrect":"$",
               "skipped":"$",
               "unscored":"$"
            },
            "noShow":"#",
            "expired":"#",
            "ndaRefused":"#",
            "deliveryEventType":"?"
         }
      ]
   },
   "vueAppointmentID":"$",
   "clientCode":"?",
   "vueCandidateID":"$",
   "clientCandidateID":"?"
}
```
3. Verify that the certificate was created in `/admin/certificates/generatedcertificate`
4. Check logs, if you didn't set `CERTIFICATE_PUBLISHER_VALID_MODES` a message with the following content must appear
`The %s certificate associated with the user <%s> and course <%s> doesn't have a valid mode and therefore its data won't be published."`

## Note
The whole integration can be tested by following this [guide](https://docs.google.com/document/d/1uzGcWyYOBqbDxzUNgtsZSk9e31P6urgzXjmM-AocZCk/edit#heading=h.7pgp0816m5td)

