### PR TITLE
feat: elegibility_appt_dates runtime calculations

### DIFF
--- a/eox_nelp/pearson_vue/pipeline.py
+++ b/eox_nelp/pearson_vue/pipeline.py
@@ -323,6 +323,12 @@ def get_exam_data(user_id, course_id, **kwargs):  # pylint: disable=unused-argum
         User.objects.get(id=user_id),
         course_id,
     )
+    # configure eligibility appt date with settings course delta starting from now. Default one year.
+    elegibility_appt_delta_days = exam_metadata.get("elegibility_appt_delta_days", 365)
+    exam_metadata["eligibility_appt_date_first"] = timezone.now().strftime("%Y/%m/%d %H:%M:%S")
+    exam_metadata["eligibility_appt_date_last"] = (
+        timezone.now() + timezone.timedelta(days=elegibility_appt_delta_days)
+    ).strftime("%Y/%m/%d %H:%M:%S")
 
     required_fields = {
         "eligibility_appt_date_first",

--- a/eox_nelp/pearson_vue/pipeline.py
+++ b/eox_nelp/pearson_vue/pipeline.py
@@ -331,8 +331,6 @@ def get_exam_data(user_id, course_id, **kwargs):  # pylint: disable=unused-argum
     ).strftime("%Y/%m/%d %H:%M:%S")
 
     required_fields = {
-        "eligibility_appt_date_first",
-        "eligibility_appt_date_last",
         "exam_authorization_count",
         "exam_series_code",
     }

--- a/eox_nelp/pearson_vue/tests/test_pipeline.py
+++ b/eox_nelp/pearson_vue/tests/test_pipeline.py
@@ -597,29 +597,31 @@ class TestGetExamData(unittest.TestCase):
         """Restore mocks' state"""
         CourseEnrollment.reset_mock()
 
+    @patch.object(timezone, "now")
     @override_settings()
-    def test_get_exam_data_success(self):
+    def test_get_exam_data_success(self, mock_now):
         """
         Test that the get_exam_data function return the set values.
 
             Expected behavior:
             - The result is the expected value.
         """
+        mock_now.return_value = timezone.datetime(2024, 5, 20, 12, 0, 0)
         exam_data = {
-            "eligibility_appt_date_first": "2024/05/05 12:00:00",
-            "eligibility_appt_date_last": "2025/05/05 12:00:00",
             "exam_authorization_count": 3,
             "exam_series_code": "ABD",
+            "eligibility_appt_date_first": mock_now().strftime("%Y/%m/%d %H:%M:%S"),
+            "eligibility_appt_date_last": (mock_now() + timezone.timedelta(days=365)).strftime("%Y/%m/%d %H:%M:%S"),
         }
         course_id = self.course_id
         course_settings = {
-            course_id: exam_data
+            course_id: exam_data.copy()
         }
         setattr(settings, "PEARSON_RTI_COURSES_DATA", course_settings)
 
         result = get_exam_data(self.user.id, course_id)
-
-        self.assertEqual(result["exam_metadata"], exam_data)
+        for key, value in exam_data.items():
+            self.assertEqual(result["exam_metadata"][key], value)
 
     @override_settings()
     def test_get_exam_data_failure(self):
@@ -634,7 +636,6 @@ class TestGetExamData(unittest.TestCase):
         course_settings = {
             course_id: {
                 "invalid_key": "test",
-                "eligibility_appt_date_last": "2024/05/05 12:00:00",
                 "exam_authorization_count": 4,
             }
         }

--- a/eox_nelp/pearson_vue/tests/test_pipeline.py
+++ b/eox_nelp/pearson_vue/tests/test_pipeline.py
@@ -607,20 +607,23 @@ class TestGetExamData(unittest.TestCase):
             - The result is the expected value.
         """
         mock_now.return_value = timezone.datetime(2024, 5, 20, 12, 0, 0)
+        course_id = self.course_id
         exam_data = {
             "exam_authorization_count": 3,
             "exam_series_code": "ABD",
+        }
+        course_settings = {
+            course_id: exam_data
+        }
+        setattr(settings, "PEARSON_RTI_COURSES_DATA", course_settings)
+        expected_data = {
+            **exam_data,
             "eligibility_appt_date_first": mock_now().strftime("%Y/%m/%d %H:%M:%S"),
             "eligibility_appt_date_last": (mock_now() + timezone.timedelta(days=365)).strftime("%Y/%m/%d %H:%M:%S"),
         }
-        course_id = self.course_id
-        course_settings = {
-            course_id: exam_data.copy()
-        }
-        setattr(settings, "PEARSON_RTI_COURSES_DATA", course_settings)
 
         result = get_exam_data(self.user.id, course_id)
-        for key, value in exam_data.items():
+        for key, value in expected_data.items():
             self.assertEqual(result["exam_metadata"][key], value)
 
     @override_settings()


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description


feat: elegibility_appt_dates runtime calculations in exam_metadata.
## Testing instructions

- Send an EAD request.
- Check the keys sent in the ead_request object. Those keys would be calculated based on "now" (eligibility_appt_date_first) and one year after (eligibility_appt_date_last).
```
eligibility_appt_date_first
eligibility_appt_date_last
```
### After
Check in audit the update data.
![image](https://github.com/user-attachments/assets/bafeb89e-fa7d-4c9e-b76a-1326874c9c31)

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
