### PR TITLE
refactor: replace generic list create api view with generic viewset a…

### DIFF
--- a/eox_nelp/pearson_vue/api/v1/urls.py
+++ b/eox_nelp/pearson_vue/api/v1/urls.py
@@ -13,7 +13,7 @@ URL Patterns:
     - revokeResult: Endpoint for revoking a result.
     - unrevokeResult: Endpoint for unrevoking a result.
 """
-from django.urls import path
+from rest_framework.routers import DefaultRouter
 
 from eox_nelp.pearson_vue.api.v1.views import (
     CancelAppointmentView,
@@ -38,13 +38,14 @@ from eox_nelp.pearson_vue.constants import (
 
 app_name = "eox_nelp"  # pylint: disable=invalid-name
 
-urlpatterns = [
-    path('resultNotification/', ResultNotificationView.as_view(), name=RESULT_NOTIFICATION),
-    path('placeHold/', PlaceHoldView.as_view(), name=PLACE_HOLD),
-    path('releaseHold/', ReleaseHoldView.as_view(), name=RELEASE_HOLD),
-    path('modifyResultStatus/', ModifyResultStatusView.as_view(), name=MODIFY_RESULT_STATUS),
-    path('revokeResult/', RevokeResultView.as_view(), name=REVOKE_RESULT),
-    path('unrevokeResult/', UnrevokeResultView.as_view(), name=UNREVOKE_RESULT),
-    path('modifyAppointment/', ModifyAppointmentView.as_view(), name=MODIFY_APPOINTMENT),
-    path('cancelAppointment/', CancelAppointmentView.as_view(), name=CANCEL_APPOINTMENT),
-]
+router = DefaultRouter()
+router.register('resultNotification', ResultNotificationView, basename=RESULT_NOTIFICATION)
+router.register('placeHold', PlaceHoldView, basename=PLACE_HOLD)
+router.register('releaseHold', ReleaseHoldView, basename=RELEASE_HOLD)
+router.register('modifyResultStatus', ModifyResultStatusView, basename=MODIFY_RESULT_STATUS)
+router.register('revokeResult', RevokeResultView, basename=REVOKE_RESULT)
+router.register('unrevokeResult', UnrevokeResultView, basename=UNREVOKE_RESULT)
+router.register('modifyAppointment', ModifyAppointmentView, basename=MODIFY_APPOINTMENT)
+router.register('cancelAppointment', CancelAppointmentView, basename=CANCEL_APPOINTMENT)
+
+urlpatterns = router.urls

--- a/eox_nelp/pearson_vue/tests/api/v1/test_views.py
+++ b/eox_nelp/pearson_vue/tests/api/v1/test_views.py
@@ -84,7 +84,7 @@ class RTENMixin:
         AnonymousUserId.objects.get.return_value.user = self.user
 
         response = self.client.post(
-            reverse(f"pearson-vue-api:v1:{self.event_type}"),
+            reverse(f"pearson-vue-api:v1:{self.event_type}-list"),
             {
                 "clientCandidateID": "NELC123456",
                 "authorization": {
@@ -122,7 +122,7 @@ class RTENMixin:
         AnonymousUserId.DoesNotExist = ObjectDoesNotExist
         AnonymousUserId.objects.get.side_effect = AnonymousUserId.DoesNotExist
 
-        response = self.client.post(reverse(f"pearson-vue-api:v1:{self.event_type}"), {}, format="json")
+        response = self.client.post(reverse(f"pearson-vue-api:v1:{self.event_type}-list"), {}, format="json")
 
         final_count = PearsonRTENEvent.objects.filter(event_type=self.event_type, candidate=None).count()
 
@@ -151,7 +151,7 @@ class RTENMixin:
         enrollment_from_id_mock.return_value = {}
 
         response = self.client.post(
-            reverse(f"pearson-vue-api:v1:{self.event_type}"),
+            reverse(f"pearson-vue-api:v1:{self.event_type}-list"),
             {"authorization": {"clientAuthorizationID": "1584-4785"}},
             format="json",
         )
@@ -185,7 +185,7 @@ class RTENMixin:
                 'created_at': event.created_at.isoformat(),
             })
 
-        response = self.client.get(reverse(f"pearson-vue-api:v1:{self.event_type}"), format="json")
+        response = self.client.get(reverse(f"pearson-vue-api:v1:{self.event_type}-list"), format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], len(events))
@@ -201,7 +201,7 @@ class RTENMixin:
         """
         initial_count = PearsonRTENEvent.objects.filter(event_type=self.event_type).count()  # pylint: disable=no-member
 
-        response = self.client.post(reverse(f"pearson-vue-api:v1:{self.event_type}"), {}, format="json")
+        response = self.client.post(reverse(f"pearson-vue-api:v1:{self.event_type}-list"), {}, format="json")
 
         final_count = PearsonRTENEvent.objects.filter(event_type=self.event_type).count()  # pylint: disable=no-member
 
@@ -216,7 +216,7 @@ class RTENMixin:
         Expected behavior:
             - Response returns a 404 status code.
         """
-        response = self.client.get(reverse(f"pearson-vue-api:v1:{self.event_type}"), format="json")
+        response = self.client.get(reverse(f"pearson-vue-api:v1:{self.event_type}-list"), format="json")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -253,7 +253,7 @@ class TestResultNotificationView(RTENMixin, unittest.TestCase):
             }
         }
 
-        response = self.client.post(reverse(f"pearson-vue-api:v1:{self.event_type}"), payload, format="json")
+        response = self.client.post(reverse(f"pearson-vue-api:v1:{self.event_type}-list"), payload, format="json")
 
         final_count = PearsonRTENEvent.objects.filter(event_type=self.event_type).count()
 


### PR DESCRIPTION

## Description

This doesn't modify anything; it simply changes the current implementation to use a viewset implementation and updates the create method to utilize the super method instead of duplicating it.

