### PR TITLE
feat: userSignUpSource create by course_enrollment

### DIFF
--- a/eox_nelp/apps.py
+++ b/eox_nelp/apps.py
@@ -64,6 +64,12 @@ class EoxNelpConfig(AppConfig):
                         'sender_path': 'common.djangoapps.student.models.CourseEnrollment',
                     },
                     {
+                        'receiver_func_name': 'create_usersignupsource_by_enrollment',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'dispatch_uid': 'create_usersignupsource_by_enrollment_receiver',
+                        'sender_path': 'common.djangoapps.student.models.CourseEnrollment',
+                    },
+                    {
                         'receiver_func_name': 'update_payment_notifications',
                         'signal_path': 'django.db.models.signals.post_save',
                         'dispatch_uid': 'update_payment_notifications_receiver',


### PR DESCRIPTION


<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

feat: userSignUpSource created by course_enrollment

Configure signal after a courseEnrollment save to create the desired UserSignUpSource record based on the course_enrollment using the org course.

## Testing instructions

### After
1. Go to UserSignUpSource in admin and select a user.
![2024-07-18_09-43](https://github.com/user-attachments/assets/aa6872bc-e177-477d-b31d-af28e4611204)
2. Go to course_enrollment in admin and select a course_enrollment related to the user and a course with an org-related site that doesn't have a UserSignUpSource record. Save the course_enrollment.
![2024-07-18_09-44](https://github.com/user-attachments/assets/ad252ed0-7e50-444b-a14d-015abfc28a91)
3. Check logs or check that the UserSignUpSource record was created.
![2024-07-18_09-23](https://github.com/user-attachments/assets/d081f41d-25a5-499e-b810-00d831c46990)
![2024-07-18_09-45](https://github.com/user-attachments/assets/762926ea-058a-4114-82fe-33fcd6a90b2c)



## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
