### PR TITLE
feat: split feature flag into read and write permissions

### DIFF
--- a/eox_nelp/pearson_vue/api/v1/views.py
+++ b/eox_nelp/pearson_vue/api/v1/views.py
@@ -65,11 +65,12 @@ class PearsonRTENBaseView(CreateModelMixin, ListModelMixin, GenericViewSet):
 
     def dispatch(self, request, *args, **kwargs):
         """
-        Override the dispatch method to check if the PEARSON_RTEN_API_ENABLED setting is active.
+        Override the dispatch method to check if specific PEARSON_RTEN_API settings are active.
 
-        This method checks if the PEARSON_RTEN_API_ENABLED setting is set to True. If it is not,
-        it raises an Http404 exception, resulting in a 404 Not Found response. If the setting
-        is active, it proceeds with the normal dispatch process.
+        This method checks the PEARSON_RTEN_API_WRITE_ENABLED and PEARSON_RTEN_API_READ_ENABLED
+        settings based on the request method. If neither setting is active for the corresponding
+        request method, it raises an Http404 exception, resulting in a 404 Not Found response.
+        If the appropriate setting is active, it proceeds with the normal dispatch process.
 
         Args:
             request (Request): The request object containing the data.
@@ -80,12 +81,35 @@ class PearsonRTENBaseView(CreateModelMixin, ListModelMixin, GenericViewSet):
             Response: Parent dispatch result.
 
         Raises:
-            Http404: If the PEARSON_RTEN_API_ENABLED setting is not active.
+            Http404: If neither the PEARSON_RTEN_API_WRITE_ENABLED nor the PEARSON_RTEN_API_READ_ENABLED
+            setting is active for the corresponding request method.
         """
-        if not getattr(settings, "PEARSON_RTEN_API_ENABLED", False):
+        if not self.is_api_enabled(request):
             raise Http404
 
         return super().dispatch(request, *args, **kwargs)
+
+    def is_api_enabled(self, request):
+        """
+        Check if the Pearson RTEN API is enabled based on the request method and relevant settings.
+
+        This method verifies the following settings:
+        - PEARSON_RTEN_API_WRITE_ENABLED: If set to True and the request method is POST, the API is enabled.
+        - PEARSON_RTEN_API_READ_ENABLED: If set to True and the request method is GET, the API is enabled.
+
+        Args:
+            request (Request): The request object containing the data.
+
+        Returns:
+            bool: True if the API is enabled based on the settings and request method, False otherwise.
+        """
+        if getattr(settings, "PEARSON_RTEN_API_WRITE_ENABLED", False) and request.method == "POST":
+            return True
+
+        if getattr(settings, "PEARSON_RTEN_API_READ_ENABLED", False) and request.method == "GET":
+            return True
+
+        return False
 
     def get_queryset(self):
         """

--- a/eox_nelp/pearson_vue/tests/api/v1/test_views.py
+++ b/eox_nelp/pearson_vue/tests/api/v1/test_views.py
@@ -210,7 +210,7 @@ class RTENMixin:
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    @override_settings(PEARSON_RTEN_API_ENABLED=False)
+    @override_settings(PEARSON_RTEN_API_WRITE_ENABLED=False)
     def test_create_result_notification_event_disabled(self):
         """
         Test creating an event when PEARSON_RTEN_ENABLED is False.
@@ -228,7 +228,7 @@ class RTENMixin:
         self.assertEqual(final_count, initial_count)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    @override_settings(PEARSON_RTEN_API_ENABLED=False)
+    @override_settings(PEARSON_RTEN_API_READ_ENABLED=False)
     def test_get_event_disabled(self):
         """
         Test retrieving an event when PEARSON_RTEN_ENABLED is False.

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -107,7 +107,8 @@ REST_FRAMEWORK = {
     },
 }
 EVENT_TRACKING_ENABLED = True
-PEARSON_RTEN_API_ENABLED = True
+PEARSON_RTEN_API_WRITE_ENABLED = True
+PEARSON_RTEN_API_READ_ENABLED = True
 
 # ------------external plugins configuration backends----------------
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR introduces improvements to the API enablement logic within an inherited view, specifically in the dispatch and is_api_enabled methods. These changes allow more granular control over API access based on the request type (GET or POST), managed by specific settings.

#### Main Changes


- The dispatch method has been updated to use the new is_api_enabled method instead of a simple check for a single setting (PEARSON_RTEN_API_ENABLED).

- Now, if the API is not enabled according to the new request method-specific settings (PEARSON_RTEN_API_WRITE_ENABLED and PEARSON_RTEN_API_READ_ENABLED), an Http404 exception is raised.


### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
