### PR TITLE
feat: implement new celery task for pearson engine integration

### DIFF
--- a/eox_nelp/pearson_vue/constants.py
+++ b/eox_nelp/pearson_vue/constants.py
@@ -104,3 +104,9 @@ PAYLOAD_EAD = """
     </soapenv:Body>
 </soapenv:Envelope>
 """
+
+ALLOWED_RTI_ACTIONS = {
+    "rti": "real_time_import",
+    "cdd": "import_candidate_demographics",
+    "ead": "import_exam_authorization",
+}

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -732,6 +732,27 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
             course_id=course_id,
         )
 
+    @override_settings(PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True, USE_PEARSON_ENGINE_SERVICE=True)
+    @patch("eox_nelp.signals.receivers.real_time_import_task_v2")
+    def test_call_async_task_v2(self, task_mock):
+        """Test that the async task is called with the right parameters
+
+        Expected behavior:
+            - delay method is called with the right values.
+        """
+        instance = Mock()
+        instance.user_id = 5
+        course_id = "course-v1:test+Cx105+2022_T4"
+        instance.context_key = CourseKey.from_string(course_id)
+
+        pearson_vue_course_completion_handler(instance)
+
+        task_mock.delay.assert_called_with(
+            user_id=instance.user_id,
+            exam_id=course_id,
+            action_name="rti"
+        )
+
 
 class PearsonVueCoursePassedHandlerTestCase(unittest.TestCase):
     """Test class for mt_course_passed_handler function."""
@@ -768,6 +789,27 @@ class PearsonVueCoursePassedHandlerTestCase(unittest.TestCase):
             user_id=user_instance.id,
             is_passing=True,
             is_graded=True
+        )
+
+    @override_settings(PEARSON_RTI_ACTIVATE_GRADED_GATE=True, USE_PEARSON_ENGINE_SERVICE=True)
+    @patch("eox_nelp.signals.receivers.real_time_import_task_v2")
+    def test_call_async_task_v2(self, task_mock):
+        """Test that the async task is called with the right parameters
+
+        Expected behavior:
+            - delay method is called with the right values.
+        """
+        course_id = "course-v1:test+Cx105+2022_T4"
+        user_instance, _ = User.objects.get_or_create(username="Severus")
+
+        pearson_vue_course_passed_handler(user_instance, CourseKey.from_string(course_id))
+
+        task_mock.delay.assert_called_with(
+            exam_id=course_id,
+            user_id=user_instance.id,
+            action_name="rti",
+            is_passing=True,
+            is_graded=True,
         )
 
 


### PR DESCRIPTION
## Description

Adds a new celery task that allows to connect previous integration with the pearson engine service. 

## Testing instructions

1. Go to current course enrollment implementation  and test all the custom actions

![image](https://github.com/user-attachments/assets/4a90719b-3514-4aee-bff4-340ca0d30d79)
![image](https://github.com/user-attachments/assets/e741335f-fd4d-4a4c-9a43-fbe7ca755291)
![image](https://github.com/user-attachments/assets/f1d9d413-ab2d-48b4-a994-11b44bcaa920)


### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
