### PR TITLE
fix: not start rti tasks if not course-config

### DIFF
--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -386,15 +386,13 @@ def pearson_vue_course_completion_handler(instance, **kwargs):  # pylint: disabl
     the pearson vue real_time_import_task , that basically runs the RTI pipeline
     on the completion logic.
     This sends only the user_id and course_id kwargs.
-    user_id -> instance.user_id
-    course_key -> instance.context_key
 
     Arguments:
         instance<Blockcompletion>: Instance of BlockCompletion model.
     """
-    if not getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False) or not getattr(
-        settings, "PEARSON_RTI_COURSES_DATA", {}
-    ).get(str(instance.context_key)):
+    if not getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False) or not str(instance.context_key) in getattr(
+        settings, "PEARSON_ENGINE_COURSES_ENABLED", []
+    ):
         return
 
     is_complete, graded = get_completed_and_graded(user_id=instance.user_id, course_id=str(instance.context_key))
@@ -430,9 +428,9 @@ def pearson_vue_course_passed_handler(user, course_id, **kwargs):  # pylint: dis
         user <User>: Instance of auth user model.
         course_id <CourseLocator>: Course locator.
     """
-    if not getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False) or not getattr(
-        settings, "PEARSON_RTI_COURSES_DATA", {}
-    ).get(str(course_id)):
+    if not getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False) or not str(course_id) in getattr(
+        settings, "PEARSON_ENGINE_COURSES_ENABLED", []
+    ):
         return
 
     LOGGER.info(

--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -392,9 +392,7 @@ def pearson_vue_course_completion_handler(instance, **kwargs):  # pylint: disabl
     Arguments:
         instance<Blockcompletion>: Instance of BlockCompletion model.
     """
-    if not getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False) or not getattr(
-        settings, "PEARSON_RTI_COURSES_DATA", {}
-    ).get(str(instance.context_key)):
+    if not getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False):
         return
 
     is_complete, graded = get_completed_and_graded(user_id=instance.user_id, course_id=str(instance.context_key))
@@ -408,12 +406,16 @@ def pearson_vue_course_completion_handler(instance, **kwargs):  # pylint: disabl
     )
 
     if getattr(settings, "USE_PEARSON_ENGINE_SERVICE", False):
+        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(instance.context_key)):
+            return
         real_time_import_task_v2.delay(
             user_id=instance.user_id,
             exam_id=str(instance.context_key),
             action_name="rti",
         )
     else:
+        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(instance.context_key)):
+            return
         real_time_import_task.delay(
             user_id=instance.user_id,
             course_id=str(instance.context_key),
@@ -430,9 +432,7 @@ def pearson_vue_course_passed_handler(user, course_id, **kwargs):  # pylint: dis
         user <User>: Instance of auth user model.
         course_id <CourseLocator>: Course locator.
     """
-    if not getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False) or not getattr(
-        settings, "PEARSON_RTI_COURSES_DATA", {}
-    ).get(str(course_id)):
+    if not getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False):
         return
 
     LOGGER.info(
@@ -441,12 +441,16 @@ def pearson_vue_course_passed_handler(user, course_id, **kwargs):  # pylint: dis
     )
 
     if getattr(settings, "USE_PEARSON_ENGINE_SERVICE", False):
+        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(course_id)):
+            return
         real_time_import_task_v2.delay(
             user_id=user.id,
             exam_id=str(course_id),
             action_name="rti",
         )
     else:
+        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(course_id)):
+            return
         real_time_import_task.delay(
             course_id=str(course_id),
             user_id=user.id,

--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -386,11 +386,15 @@ def pearson_vue_course_completion_handler(instance, **kwargs):  # pylint: disabl
     the pearson vue real_time_import_task , that basically runs the RTI pipeline
     on the completion logic.
     This sends only the user_id and course_id kwargs.
+    user_id -> instance.user_id
+    course_key -> instance.context_key
 
     Arguments:
         instance<Blockcompletion>: Instance of BlockCompletion model.
     """
-    if not getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False):
+    if not getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False) or not getattr(
+        settings, "PEARSON_RTI_COURSES_DATA", {}
+    ).get(str(instance.context_key)):
         return
 
     is_complete, graded = get_completed_and_graded(user_id=instance.user_id, course_id=str(instance.context_key))
@@ -426,7 +430,9 @@ def pearson_vue_course_passed_handler(user, course_id, **kwargs):  # pylint: dis
         user <User>: Instance of auth user model.
         course_id <CourseLocator>: Course locator.
     """
-    if not getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False):
+    if not getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False) or not getattr(
+        settings, "PEARSON_RTI_COURSES_DATA", {}
+    ).get(str(course_id)):
         return
 
     LOGGER.info(

--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -406,7 +406,7 @@ def pearson_vue_course_completion_handler(instance, **kwargs):  # pylint: disabl
     )
 
     if getattr(settings, "USE_PEARSON_ENGINE_SERVICE", False):
-        if not getattr(settings, "PEARSON_ENGINE_COURSES_ENABLED", {}).get(str(instance.context_key)):
+        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(instance.context_key)):
             return
         real_time_import_task_v2.delay(
             user_id=instance.user_id,
@@ -441,7 +441,7 @@ def pearson_vue_course_passed_handler(user, course_id, **kwargs):  # pylint: dis
     )
 
     if getattr(settings, "USE_PEARSON_ENGINE_SERVICE", False):
-        if not getattr(settings, "PEARSON_ENGINE_COURSES_ENABLED", {}).get(str(course_id)):
+        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(course_id)):
             return
         real_time_import_task_v2.delay(
             user_id=user.id,

--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -406,7 +406,7 @@ def pearson_vue_course_completion_handler(instance, **kwargs):  # pylint: disabl
     )
 
     if getattr(settings, "USE_PEARSON_ENGINE_SERVICE", False):
-        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(instance.context_key)):
+        if not getattr(settings, "PEARSON_ENGINE_COURSES_ENABLED", {}).get(str(instance.context_key)):
             return
         real_time_import_task_v2.delay(
             user_id=instance.user_id,
@@ -441,7 +441,7 @@ def pearson_vue_course_passed_handler(user, course_id, **kwargs):  # pylint: dis
     )
 
     if getattr(settings, "USE_PEARSON_ENGINE_SERVICE", False):
-        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(course_id)):
+        if not getattr(settings, "PEARSON_ENGINE_COURSES_ENABLED", {}).get(str(course_id)):
             return
         real_time_import_task_v2.delay(
             user_id=user.id,

--- a/eox_nelp/signals/receivers.py
+++ b/eox_nelp/signals/receivers.py
@@ -392,7 +392,9 @@ def pearson_vue_course_completion_handler(instance, **kwargs):  # pylint: disabl
     Arguments:
         instance<Blockcompletion>: Instance of BlockCompletion model.
     """
-    if not getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False):
+    if not getattr(settings, "PEARSON_RTI_ACTIVATE_COMPLETION_GATE", False) or not getattr(
+        settings, "PEARSON_RTI_COURSES_DATA", {}
+    ).get(str(instance.context_key)):
         return
 
     is_complete, graded = get_completed_and_graded(user_id=instance.user_id, course_id=str(instance.context_key))
@@ -406,16 +408,12 @@ def pearson_vue_course_completion_handler(instance, **kwargs):  # pylint: disabl
     )
 
     if getattr(settings, "USE_PEARSON_ENGINE_SERVICE", False):
-        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(instance.context_key)):
-            return
         real_time_import_task_v2.delay(
             user_id=instance.user_id,
             exam_id=str(instance.context_key),
             action_name="rti",
         )
     else:
-        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(instance.context_key)):
-            return
         real_time_import_task.delay(
             user_id=instance.user_id,
             course_id=str(instance.context_key),
@@ -432,7 +430,9 @@ def pearson_vue_course_passed_handler(user, course_id, **kwargs):  # pylint: dis
         user <User>: Instance of auth user model.
         course_id <CourseLocator>: Course locator.
     """
-    if not getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False):
+    if not getattr(settings, "PEARSON_RTI_ACTIVATE_GRADED_GATE", False) or not getattr(
+        settings, "PEARSON_RTI_COURSES_DATA", {}
+    ).get(str(course_id)):
         return
 
     LOGGER.info(
@@ -441,16 +441,12 @@ def pearson_vue_course_passed_handler(user, course_id, **kwargs):  # pylint: dis
     )
 
     if getattr(settings, "USE_PEARSON_ENGINE_SERVICE", False):
-        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(course_id)):
-            return
         real_time_import_task_v2.delay(
             user_id=user.id,
             exam_id=str(course_id),
             action_name="rti",
         )
     else:
-        if not getattr(settings, "PEARSON_RTI_COURSES_DATA", {}).get(str(course_id)):
-            return
         real_time_import_task.delay(
             course_id=str(course_id),
             user_id=user.id,

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -723,11 +723,10 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
 
         task_mock.delay.assert_not_called()
 
-    @override_settings(PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True)
     @data({}, {"course-v1:notdesired": {"exam_series_code": "OTT"}}, {"key": 6})
-    @patch("eox_nelp.signals.receivers.get_completed_and_graded")
+    @override_settings(PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True)
     @patch("eox_nelp.signals.receivers.real_time_import_task")
-    def test_invalid_course_configuration(self, wrong_course_config, task_mock, get_completed_and_graded_mock):
+    def test_invalid_course_configuration(self, wrong_course_config, task_mock):
         """Test when the PEARSON_RTI_ACTIVATE_COMPLETION_GATE settings is True,
         but invalid course  configuration for PEARSON_RTI_COURSES_DATA.
         Expected behavior:
@@ -736,7 +735,6 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
         instance = Mock()
         instance.user_id = self.user_id
         instance.context_key = CourseKey.from_string(self.course_id)
-        get_completed_and_graded_mock.return_value = (True, False)
         setattr(settings, "PEARSON_RTI_COURSES_DATA", wrong_course_config)
 
         pearson_vue_course_completion_handler(instance)

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -723,10 +723,11 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
 
         task_mock.delay.assert_not_called()
 
-    @data({}, {"course-v1:notdesired": {"exam_series_code": "OTT"}}, {"key": 6})
     @override_settings(PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True)
+    @data({}, {"course-v1:notdesired": {"exam_series_code": "OTT"}}, {"key": 6})
+    @patch("eox_nelp.signals.receivers.get_completed_and_graded")
     @patch("eox_nelp.signals.receivers.real_time_import_task")
-    def test_invalid_course_configuration(self, wrong_course_config, task_mock):
+    def test_invalid_course_configuration(self, wrong_course_config, task_mock, get_completed_and_graded_mock):
         """Test when the PEARSON_RTI_ACTIVATE_COMPLETION_GATE settings is True,
         but invalid course  configuration for PEARSON_RTI_COURSES_DATA.
         Expected behavior:
@@ -735,6 +736,7 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
         instance = Mock()
         instance.user_id = self.user_id
         instance.context_key = CourseKey.from_string(self.course_id)
+        get_completed_and_graded_mock.return_value = (True, False)
         setattr(settings, "PEARSON_RTI_COURSES_DATA", wrong_course_config)
 
         pearson_vue_course_completion_handler(instance)

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -769,10 +769,7 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
 
         task_mock.delay.assert_not_called()
 
-    @override_settings(
-        PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True,
-        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
-    )
+    @override_settings(PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True, PEARSON_RTI_COURSES_DATA=course_exam_configuration,)
     @patch("eox_nelp.signals.receivers.get_completed_and_graded")
     @patch("eox_nelp.signals.receivers.real_time_import_task")
     def test_call_async_task(self, task_mock, get_completed_and_graded_mock):
@@ -796,7 +793,7 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
     @override_settings(
         PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True,
         USE_PEARSON_ENGINE_SERVICE=True,
-        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
+        PEARSON_ENGINE_COURSES_ENABLED=course_exam_configuration,
     )
     @patch("eox_nelp.signals.receivers.get_completed_and_graded")
     @patch("eox_nelp.signals.receivers.real_time_import_task_v2")
@@ -858,10 +855,7 @@ class PearsonVueCoursePassedHandlerTestCase(unittest.TestCase):
 
         task_mock.delay.assert_not_called()
 
-    @override_settings(
-        PEARSON_RTI_ACTIVATE_GRADED_GATE=True,
-        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
-    )
+    @override_settings(PEARSON_RTI_ACTIVATE_GRADED_GATE=True, PEARSON_RTI_COURSES_DATA=course_exam_configuration,)
     @patch("eox_nelp.signals.receivers.real_time_import_task")
     def test_call_async_task(self, task_mock):
         """Test that the async task is called with the right parameters
@@ -881,7 +875,7 @@ class PearsonVueCoursePassedHandlerTestCase(unittest.TestCase):
     @override_settings(
         PEARSON_RTI_ACTIVATE_GRADED_GATE=True,
         USE_PEARSON_ENGINE_SERVICE=True,
-        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
+        PEARSON_ENGINE_COURSES_ENABLED=course_exam_configuration,
     )
     @patch("eox_nelp.signals.receivers.real_time_import_task_v2")
     def test_call_async_task_v2(self, task_mock):

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -12,6 +12,7 @@ Classes:
 import unittest
 
 from ddt import data, ddt
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.utils import timezone
@@ -697,7 +698,16 @@ class MtCourseFailedHandlerTestCase(unittest.TestCase):
 @ddt
 class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
     """Test class for pearson_vue_course_completion_handler function."""
+    course_id = "course-v1:test+Cx105+2022_T4"
+    user_id = 5
+    course_exam_configuration = {
+        course_id: {
+            "exam_authorization_count": 3,
+            "exam_series_code": "OTT"
+        },
+    }
 
+    @override_settings(PEARSON_RTI_COURSES_DATA=course_exam_configuration)
     @patch("eox_nelp.signals.receivers.real_time_import_task")
     def test_invalid_feature_flag(self, task_mock):
         """Test when the PEARSON_RTI_ACTIVATE_COMPLETION_GATE settings is False.
@@ -706,20 +716,40 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
             - real_time_import_task mock has not been called.
         """
         instance = Mock()
-        instance.user_id = 17
-        course_id = "course-v1:test+Cx105+2022_T4"
-        instance.context_key = CourseKey.from_string(course_id)
+        instance.user_id = self.user_id
+        instance.context_key = CourseKey.from_string(self.course_id)
 
         pearson_vue_course_completion_handler(instance)
 
         task_mock.delay.assert_not_called()
 
+    @data({}, {"course-v1:notdesired": {"exam_series_code": "OTT"}}, {"key": 6})
+    @override_settings(PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True)
+    @patch("eox_nelp.signals.receivers.real_time_import_task")
+    def test_invalid_course_configuration(self, wrong_course_config, task_mock):
+        """Test when the PEARSON_RTI_ACTIVATE_COMPLETION_GATE settings is True,
+        but invalid course  configuration for PEARSON_RTI_COURSES_DATA.
+        Expected behavior:
+            - real_time_import_task mock has not been called.
+        """
+        instance = Mock()
+        instance.user_id = self.user_id
+        instance.context_key = CourseKey.from_string(self.course_id)
+        setattr(settings, "PEARSON_RTI_COURSES_DATA", wrong_course_config)
+
+        pearson_vue_course_completion_handler(instance)
+
+        task_mock.delay.assert_not_called()
+
+    @override_settings(
+        PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True,
+        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
+    )
     @data(  # is_complete and graded values respectively
         (True, True),
         (False, True),
         (False, False),
     )
-    @override_settings(PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True)
     @patch("eox_nelp.signals.receivers.get_completed_and_graded")
     @patch("eox_nelp.signals.receivers.real_time_import_task")
     def test_invalid_course_state(self, invalid_state, task_mock, get_completed_and_graded_mock):
@@ -729,16 +759,18 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
             - real_time_import_task mock has not been called.
         """
         instance = Mock()
-        instance.user_id = 17
-        course_id = "course-v1:test+Cx105+2022_T4"
-        instance.context_key = CourseKey.from_string(course_id)
+        instance.user_id = self.user_id
+        instance.context_key = CourseKey.from_string(self.course_id)
         get_completed_and_graded_mock.return_value = invalid_state
 
         pearson_vue_course_completion_handler(instance)
 
         task_mock.delay.assert_not_called()
 
-    @override_settings(PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True)
+    @override_settings(
+        PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True,
+        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
+    )
     @patch("eox_nelp.signals.receivers.get_completed_and_graded")
     @patch("eox_nelp.signals.receivers.real_time_import_task")
     def test_call_async_task(self, task_mock, get_completed_and_graded_mock):
@@ -748,19 +780,22 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
             - delay method is called with the right values.
         """
         instance = Mock()
-        instance.user_id = 5
-        course_id = "course-v1:test+Cx105+2022_T4"
-        instance.context_key = CourseKey.from_string(course_id)
+        instance.user_id = self.user_id
+        instance.context_key = CourseKey.from_string(self.course_id)
         get_completed_and_graded_mock.return_value = (True, False)  # is_complete and graded values respectively
 
         pearson_vue_course_completion_handler(instance)
 
         task_mock.delay.assert_called_with(
             user_id=instance.user_id,
-            course_id=course_id,
+            course_id=self.course_id,
         )
 
-    @override_settings(PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True, USE_PEARSON_ENGINE_SERVICE=True)
+    @override_settings(
+        PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True,
+        USE_PEARSON_ENGINE_SERVICE=True,
+        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
+    )
     @patch("eox_nelp.signals.receivers.get_completed_and_graded")
     @patch("eox_nelp.signals.receivers.real_time_import_task_v2")
     def test_call_async_task_v2(self, task_mock, get_completed_and_graded_mock):
@@ -770,23 +805,28 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
             - delay method is called with the right values.
         """
         instance = Mock()
-        instance.user_id = 5
-        course_id = "course-v1:test+Cx105+2022_T4"
-        instance.context_key = CourseKey.from_string(course_id)
+        instance.user_id = self.user_id
+        instance.context_key = CourseKey.from_string(self.course_id)
         get_completed_and_graded_mock.return_value = (True, False)  # is_complete and graded values respectively
 
         pearson_vue_course_completion_handler(instance)
 
         task_mock.delay.assert_called_with(
             user_id=instance.user_id,
-            exam_id=course_id,
+            exam_id=self.course_id,
             action_name="rti"
         )
 
 
+@ddt
 class PearsonVueCoursePassedHandlerTestCase(unittest.TestCase):
     """Test class for mt_course_passed_handler function."""
+    course_id = "course-v1:test+Cz105+2022_T4"
+    course_exam_configuration = {
+        course_id: True,
+    }
 
+    @override_settings(PEARSON_RTI_COURSES_DATA=course_exam_configuration)
     @patch("eox_nelp.signals.receivers.update_mt_training_stage")
     def test_invalid_feature_flag(self, task_mock):
         """Test when the PEARSON_RTI_ACTIVATE_GRADED_GATE settings is False.
@@ -794,14 +834,32 @@ class PearsonVueCoursePassedHandlerTestCase(unittest.TestCase):
         Expected behavior:
             - real_time_import_task mock has not been called.
         """
-        course_id = "course-v1:test+Cx105+2022_T4"
         user_instance, _ = User.objects.get_or_create(username="Severus")
 
-        pearson_vue_course_passed_handler(user_instance, CourseKey.from_string(course_id))
+        pearson_vue_course_passed_handler(user_instance, CourseKey.from_string(self.course_id))
 
         task_mock.delay.assert_not_called()
 
     @override_settings(PEARSON_RTI_ACTIVATE_GRADED_GATE=True)
+    @data({}, {"course-v1:notdesired": True}, {"key": 6})
+    @patch("eox_nelp.signals.receivers.update_mt_training_stage")
+    def test_invalid_course_configuration(self, wrong_course_config, task_mock):
+        """Test when the PEARSON_RTI_ACTIVATE_GRADED_GATE settings is True,
+        but invalid course configuration for PEARSON_RTI_COURSES_DATA
+
+        Expected behavior:
+            - real_time_import_task mock has not been called.
+        """
+        user_instance, _ = User.objects.get_or_create(username="Severus")
+        setattr(settings, "PEARSON_RTI_COURSES_DATA", wrong_course_config)
+        pearson_vue_course_passed_handler(user_instance, CourseKey.from_string(self.course_id))
+
+        task_mock.delay.assert_not_called()
+
+    @override_settings(
+        PEARSON_RTI_ACTIVATE_GRADED_GATE=True,
+        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
+    )
     @patch("eox_nelp.signals.receivers.real_time_import_task")
     def test_call_async_task(self, task_mock):
         """Test that the async task is called with the right parameters
@@ -809,17 +867,20 @@ class PearsonVueCoursePassedHandlerTestCase(unittest.TestCase):
         Expected behavior:
             - delay method is called with the right values.
         """
-        course_id = "course-v1:test+Cx105+2022_T4"
         user_instance, _ = User.objects.get_or_create(username="Severus")
 
-        pearson_vue_course_passed_handler(user_instance, CourseKey.from_string(course_id))
+        pearson_vue_course_passed_handler(user_instance, CourseKey.from_string(self.course_id))
 
         task_mock.delay.assert_called_with(
-            course_id=course_id,
+            course_id=self.course_id,
             user_id=user_instance.id,
         )
 
-    @override_settings(PEARSON_RTI_ACTIVATE_GRADED_GATE=True, USE_PEARSON_ENGINE_SERVICE=True)
+    @override_settings(
+        PEARSON_RTI_ACTIVATE_GRADED_GATE=True,
+        USE_PEARSON_ENGINE_SERVICE=True,
+        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
+    )
     @patch("eox_nelp.signals.receivers.real_time_import_task_v2")
     def test_call_async_task_v2(self, task_mock):
         """Test that the async task is called with the right parameters
@@ -827,13 +888,12 @@ class PearsonVueCoursePassedHandlerTestCase(unittest.TestCase):
         Expected behavior:
             - delay method is called with the right values.
         """
-        course_id = "course-v1:test+Cx105+2022_T4"
         user_instance, _ = User.objects.get_or_create(username="Severus")
 
-        pearson_vue_course_passed_handler(user_instance, CourseKey.from_string(course_id))
+        pearson_vue_course_passed_handler(user_instance, CourseKey.from_string(self.course_id))
 
         task_mock.delay.assert_called_with(
-            exam_id=course_id,
+            exam_id=self.course_id,
             user_id=user_instance.id,
             action_name="rti",
         )

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -769,7 +769,10 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
 
         task_mock.delay.assert_not_called()
 
-    @override_settings(PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True, PEARSON_RTI_COURSES_DATA=course_exam_configuration,)
+    @override_settings(
+        PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True,
+        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
+    )
     @patch("eox_nelp.signals.receivers.get_completed_and_graded")
     @patch("eox_nelp.signals.receivers.real_time_import_task")
     def test_call_async_task(self, task_mock, get_completed_and_graded_mock):
@@ -793,7 +796,7 @@ class PearsonVueCompletionHandlerTestCase(unittest.TestCase):
     @override_settings(
         PEARSON_RTI_ACTIVATE_COMPLETION_GATE=True,
         USE_PEARSON_ENGINE_SERVICE=True,
-        PEARSON_ENGINE_COURSES_ENABLED=course_exam_configuration,
+        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
     )
     @patch("eox_nelp.signals.receivers.get_completed_and_graded")
     @patch("eox_nelp.signals.receivers.real_time_import_task_v2")
@@ -855,7 +858,10 @@ class PearsonVueCoursePassedHandlerTestCase(unittest.TestCase):
 
         task_mock.delay.assert_not_called()
 
-    @override_settings(PEARSON_RTI_ACTIVATE_GRADED_GATE=True, PEARSON_RTI_COURSES_DATA=course_exam_configuration,)
+    @override_settings(
+        PEARSON_RTI_ACTIVATE_GRADED_GATE=True,
+        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
+    )
     @patch("eox_nelp.signals.receivers.real_time_import_task")
     def test_call_async_task(self, task_mock):
         """Test that the async task is called with the right parameters
@@ -875,7 +881,7 @@ class PearsonVueCoursePassedHandlerTestCase(unittest.TestCase):
     @override_settings(
         PEARSON_RTI_ACTIVATE_GRADED_GATE=True,
         USE_PEARSON_ENGINE_SERVICE=True,
-        PEARSON_ENGINE_COURSES_ENABLED=course_exam_configuration,
+        PEARSON_RTI_COURSES_DATA=course_exam_configuration,
     )
     @patch("eox_nelp.signals.receivers.real_time_import_task_v2")
     def test_call_async_task_v2(self, task_mock):


### PR DESCRIPTION
# Description

Check the existence of course-config for the processed course_id.
If there is not course-config (`PEARSON_RTI_COURSES_DATA`) for the desired course,
RTI requests would not be sent.

Refactored a little the tests.

<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.f
🙈 Don't be lazy, try to fill out the template well.
-->


## Testing instructions

### Before

### After

## Additional information

**[Jira story](https://edunext.atlassian.net/browse/FUTUREX-877?atlOrigin=eyJpIjoiMjNiMzZmNmU3ZWU4NDhmNzg0N2EzNTM4ZmNkZDg3MTkiLCJwIjoiaiJ9)**: 

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
