### PR TITLE
feat:  restrict admin actions based on the settings configuration.

### DIFF
--- a/eox_nelp/admin/tests/__init__.py
+++ b/eox_nelp/admin/tests/__init__.py
@@ -64,63 +64,6 @@ class TestPearsonAction(TestCase):
 
     @data(
         {
-            "mock_task": "eox_nelp.pearson_vue.tasks.real_time_import_task.delay",
-            "admin_action": pearson_real_time_action,
-            "call_args": ["user_id", "course_id"],
-            "extra_call_kwargs": {
-            },
-        },
-        {
-            "mock_task": "eox_nelp.pearson_vue.tasks.ead_task.delay",
-            "admin_action": pearson_add_ead_action,
-            "call_args": ["user_id", "course_id"],
-            "extra_call_kwargs": {
-                "transaction_type": "Add",
-            },
-
-        },
-        {
-            "mock_task": "eox_nelp.pearson_vue.tasks.ead_task.delay",
-            "admin_action": pearson_update_ead_action,
-            "call_args": ["user_id", "course_id"],
-            "extra_call_kwargs": {
-                "transaction_type": "Update",
-            },
-        },
-        {
-            "mock_task": "eox_nelp.pearson_vue.tasks.ead_task.delay",
-            "admin_action": pearson_delete_ead_action,
-            "call_args": ["user_id", "course_id"],
-            "extra_call_kwargs": {
-                "transaction_type": "Delete",
-            },
-        },
-        {
-            "mock_task": "eox_nelp.pearson_vue.tasks.cdd_task.delay",
-            "admin_action": pearson_cdd_action,
-            "call_args": ["user_id"],
-            "extra_call_kwargs": {
-            },
-        },
-    )
-    @unpack
-    def test_pearson_course_enrollment_action(self, mock_task, admin_action, call_args, extra_call_kwargs):
-        """
-        Test that a pearson_action function calls a task delay with correct parameters.
-        """
-        queryset = [
-            self._create_mock_enrollment("course-v1:TestX+T101+2024_T1"),
-            self._create_mock_enrollment("course-v1:FutureX+T102+2025_T1"),
-        ]
-        mocks_call_kwargs = self._prepare_call_kwargs(queryset, call_args, extra_call_kwargs)
-
-        # Call the admin action
-        with patch(mock_task) as mocked_task:
-            admin_action(MagicMock(), self.request, queryset)
-            self._assert_mocked_task_calls(mocked_task, mocks_call_kwargs)
-
-    @data(
-        {
             "admin_action": pearson_real_time_action,
             "call_args": ["user_id", "exam_id"],
             "extra_call_kwargs": {
@@ -197,6 +140,7 @@ class TestNelpCourseEnrollmentAdmin(TestCase):
         pearson_real_time_action,
         pearson_update_ead_action,
     )
+    @override_settings(USE_PEARSON_ENGINE_SERVICE=True)
     def test_actions(self, admin_action):
         """
         Test that the actions list contains pearson_real_time_action.


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description
This removes the old pearson vue admin implementation in favor of the pearson engine feature, this also allow to control  the action visibility based on the `USE_PEARSON_ENGINE_SERVICE` value

## Testing instructions

1. Set the setting `USE_PEARSON_ENGINE_SERVICE` to false 
2. Go to  `/admin/student/courseenrollment/`
3.  Check that there are no actions
4. Set the setting `USE_PEARSON_ENGINE_SERVICE` to true 
5. Go to  `/admin/student/courseenrollment/`
6. Check that the Pearson actions appear

