### PR TITLE
feat: send national id to pearson engine service

### DIFF
--- a/eox_nelp/api_clients/pearson_engine.py
+++ b/eox_nelp/api_clients/pearson_engine.py
@@ -54,6 +54,7 @@ class PearsonEngineApiClient(AbstractAPIRestClient):
             "address": user.profile.mailing_address,
             "arabic_first_name": user.extrainfo.arabic_first_name,
             "arabic_last_name": user.extrainfo.arabic_last_name,
+            "national_id": user.extrainfo.national_id,
         }
 
     def _get_platform_data(self):

--- a/eox_nelp/api_clients/tests/test_pearson_engine.py
+++ b/eox_nelp/api_clients/tests/test_pearson_engine.py
@@ -143,6 +143,7 @@ class TestPearsonEngineApiClient(TestRestApiClientMixin, TestOauth2Authenticator
             class ExtraInfo:
                 arabic_first_name = "اختبار"
                 arabic_last_name = "مستخدم"
+                national_id = "1234567890"
 
             profile = Profile()
             extrainfo = ExtraInfo()


### PR DESCRIPTION
## Description

This adds the national id to the user_data which is send to the Pearson engine service 

## Testing instructions

### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
