### PR TITLE
fix: don't send empty national ids

### DIFF
--- a/eox_nelp/api_clients/pearson_engine.py
+++ b/eox_nelp/api_clients/pearson_engine.py
@@ -43,7 +43,7 @@ class PearsonEngineApiClient(AbstractAPIRestClient):
         Returns:
             dict: The user data formatted for the request.
         """
-        return {
+        user_data = {
             "username": user.username,
             "first_name": user.first_name,
             "last_name": user.last_name,
@@ -54,8 +54,12 @@ class PearsonEngineApiClient(AbstractAPIRestClient):
             "address": user.profile.mailing_address,
             "arabic_first_name": user.extrainfo.arabic_first_name,
             "arabic_last_name": user.extrainfo.arabic_last_name,
-            "national_id": user.extrainfo.national_id,
         }
+
+        if user.extrainfo.national_id:
+            user_data["national_id"] = user.extrainfo.national_id
+
+        return user_data
 
     def _get_platform_data(self):
         """


### PR DESCRIPTION
## Description

This modification adds a condition to the national_id key, if the value is empty that won't be sent 

## Testing instructions

### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
