### PR TITLE
Jlc/NIDpipelines

### DIFF
--- a/eox_nelp/third_party_auth/tests/test_pipeline.py
+++ b/eox_nelp/third_party_auth/tests/test_pipeline.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from mock import Mock
 from rest_framework import status
 
-from eox_nelp.third_party_auth import pipeline
+from eox_nelp.third_party_auth import utils
 from eox_nelp.third_party_auth.pipeline import (
     disallow_staff_superuser_users,
     safer_associate_user_by_national_id,
@@ -80,9 +80,11 @@ class SaferAssociateUserUsingUid(SetUpPipeMixin):
         exc_msg = "return 7"
         self.backend.strategy.storage.user.get_user.side_effect = MultipleObjectsReturned(exc_msg)
         expected_log = [
-            f"INFO:{pipeline.__name__}:"
-            f"Pipeline tries to match user with uid({test_uid}) but Multiple users found: {exc_msg}"]
-        with self.assertLogs(pipeline.__name__, level="INFO") as logs:
+            f"INFO:{utils.__name__}:"
+            f"Pipeline tries to match user with uid({test_uid}) using {self.user_query}, "
+            f"but Multiple users found: {exc_msg}"
+        ]
+        with self.assertLogs(utils.__name__, level="INFO") as logs:
             pipe_output = self.uid_pipe(self.request, self.backend, self.details, self.response)
             self.assertIsNone(pipe_output)
         self.assertListEqual(logs.output, expected_log)

--- a/eox_nelp/third_party_auth/tests/test_pipeline.py
+++ b/eox_nelp/third_party_auth/tests/test_pipeline.py
@@ -1,20 +1,24 @@
 """ Test file for third_party_auth pipeline functions."""
 from ddt import data, ddt
 from django.contrib.auth import get_user_model
+from django.core.exceptions import MultipleObjectsReturned
 from django.http import HttpResponseForbidden
 from django.test import TestCase
 from mock import Mock
 from rest_framework import status
 
-from eox_nelp.third_party_auth.pipeline import safer_associate_username_by_uid
+from eox_nelp.third_party_auth import pipeline
+from eox_nelp.third_party_auth.pipeline import (
+    disallow_staff_superuser_users,
+    safer_associate_user_by_national_id,
+    safer_associate_user_by_social_auth_record,
+)
 
 User = get_user_model()
 
 
-@ddt
-class SaferAssociaciateUsernameUidTestCase(TestCase):
-    """Test class for safer_associate_username_by_uid method"""
-
+class SetUpPipeMixin:
+    """Mixin for SetUp pipelines"""
     def setUp(self):  # pylint: disable=invalid-name
         """
         Set base variables and objects across experience test cases.
@@ -28,19 +32,28 @@ class SaferAssociaciateUsernameUidTestCase(TestCase):
         self.backend = Mock()
         self.request = Mock()
 
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Reset mocks"""
+        self.backend.reset_mock()
+        self.request.reset_mock()
+
+
+class SaferAssociateUserUsingUid(SetUpPipeMixin):
+    """Mixin for pipes that match user using uid"""
+    # pylint: disable=no-member
     def test_user_already_matched(self):
         """Test the pipeline method is called with already matched user.
         Expected behavior:
             - Return None.
         """
-        pipe_output = safer_associate_username_by_uid(
+        pipe_output = self.uid_pipe(
             self.request, self.backend, self.details, self.response, user=self.user,
         )
 
         self.assertIsNone(pipe_output)
 
     def test_user_not_associated(self):
-        """Test the pipeline method try to match with uid but there is not user with that username.
+        """Test the pipeline method try to match with uid but there is not user with that match.
         Expected behavior:
             - Pipe method returns None.
             - Strategy storage get_user method is called with desired params.
@@ -50,36 +63,37 @@ class SaferAssociaciateUsernameUidTestCase(TestCase):
         self.backend.get_idp.return_value.get_user_permanent_id.return_value = test_uid
         self.backend.strategy.storage.user.get_user.return_value = None
 
-        pipe_output = safer_associate_username_by_uid(self.request, self.backend, self.details, self.response)
+        pipe_output = self.uid_pipe(self.request, self.backend, self.details, self.response)
 
-        self.assertEqual(None, pipe_output)
-        self.backend.strategy.storage.user.get_user.assert_called_with(username=test_uid)
+        self.assertIsNone(pipe_output)
+        self.backend.strategy.storage.user.get_user.assert_called_with(**{self.user_query: test_uid})
 
-    @data(
-        {"is_staff": True, "username": "1222333444"},
-        {"is_superuser": True, "username": "1222333555"},
-    )
-    def test_staff_user_return_forbidden(self, user_kwargs):
-        """Test the pipeline method try to match with uid, the user with matched username exists
-        but is staff or superuser.
+    def test_multiple_user_match(self):
+        """Test the pipeline method try to match with uid but there are multiple matches.
         Expected behavior:
-            - The pipe method returns an HttpResponseForbidden object.
-            - The pipe method response has a 403 forbidden status.
-            - Strategy storage get_user method is called with desired params.
+            - Expected logs of multiple returns
+            - Pipe method returns None.
         """
-        test_uid = user_kwargs["username"]
-        past_user, _ = User.objects.get_or_create(**user_kwargs)
+        test_uid = "1888222999"
 
         self.backend.get_idp.return_value.get_user_permanent_id.return_value = test_uid
-        self.backend.strategy.storage.user.get_user.return_value = past_user
+        exc_msg = "return 7"
+        self.backend.strategy.storage.user.get_user.side_effect = MultipleObjectsReturned(exc_msg)
+        expected_log = [
+            f"INFO:{pipeline.__name__}:"
+            f"Pipeline tries to match user with uid({test_uid}) but Multiple users found: {exc_msg}"]
+        with self.assertLogs(pipeline.__name__, level="INFO") as logs:
+            pipe_output = self.uid_pipe(self.request, self.backend, self.details, self.response)
+            self.assertIsNone(pipe_output)
+        self.assertListEqual(logs.output, expected_log)
 
-        pipe_output = safer_associate_username_by_uid(self.request, self.backend, self.details, self.response)
 
-        self.assertIsInstance(pipe_output, HttpResponseForbidden)
-        self.assertEqual(status.HTTP_403_FORBIDDEN, pipe_output.status_code)
-        self.backend.strategy.storage.user.get_user.assert_called_with(username=test_uid)
+class SaferAssociaciateUserByNationalIdTestCase(SaferAssociateUserUsingUid, TestCase):
+    """Test case for `safer_associate_user_by_national_id` method"""
+    uid_pipe = staticmethod(safer_associate_user_by_national_id)
+    user_query = "extrainfo__national_id"
 
-    def test_user_associate_username_with_uid(self):
+    def test_user_associate_uid_with_national_id(self):
         """Test the pipeline method try to match with uid, the user with matched username exists
         and is returned.
         Expected behavior:
@@ -94,7 +108,75 @@ class SaferAssociaciateUsernameUidTestCase(TestCase):
         self.backend.get_idp.return_value.get_user_permanent_id.return_value = test_uid
         self.backend.strategy.storage.user.get_user.return_value = past_user
 
-        pipe_output = safer_associate_username_by_uid(self.request, self.backend, self.details, self.response)
+        pipe_output = safer_associate_user_by_national_id(self.request, self.backend, self.details, self.response)
 
         self.assertEqual({"user": past_user, "is_new": False}, pipe_output)
-        self.backend.strategy.storage.user.get_user.assert_called_with(username=test_uid)
+        self.backend.strategy.storage.user.get_user.assert_called_with(**{self.user_query: test_uid})
+
+
+class SaferAssociaciateUserBySocialAuthRecordTestCase(SaferAssociateUserUsingUid, TestCase):
+    """Test case for `safer_associate_user_by_social_auth_record`"""
+    uid_pipe = staticmethod(safer_associate_user_by_social_auth_record)
+    user_query = "social_auth__uid__endswith"
+
+    def test_user_associate_uid_with_social_record(self):
+        """Test the pipeline method try to match with uid, the user with matched query exists
+        and is returned.
+        Expected behavior:
+            - Strategy storage get_user method is called with desired params.
+            - The method returns the desirect with `user` and `is_new` keys.
+        """
+        test_uid = "1777888999"
+        past_user, _ = User.objects.get_or_create(
+            username=test_uid,
+        )
+
+        self.backend.get_idp.return_value.get_user_permanent_id.return_value = test_uid
+        self.backend.strategy.storage.user.get_user.return_value = past_user
+
+        pipe_output = safer_associate_user_by_social_auth_record(
+            self.request,
+            self.backend,
+            self.details,
+            self.response,
+        )
+
+        self.assertEqual({"user": past_user, "is_new": False}, pipe_output)
+        self.backend.strategy.storage.user.get_user.assert_called_with(**{self.user_query: test_uid})
+
+
+@ddt
+class DisallowStaffSuperuserUsersTestCase(SetUpPipeMixin, TestCase):
+    """Test class for pipe `disallow_staff_superusers_users`"""
+    @data(
+        {"is_staff": True, "username": "1222333444"},
+        {"is_superuser": True, "username": "1222333555"},
+    )
+    def test_staff_user_return_forbidden(self, user_queries):
+        """Test the pipeline receive a not allower staff or superuser.
+        Expected behavior:
+            - The pipe method returns an HttpResponseForbidden object.
+            - The pipe method response has a 403 forbidden status.
+        """
+        past_user, _ = User.objects.get_or_create(**user_queries)
+
+        pipe_output = disallow_staff_superuser_users(
+            self.request,
+            self.backend,
+            self.details,
+            self.response,
+            user=past_user
+        )
+
+        self.assertIsInstance(pipe_output, HttpResponseForbidden)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, pipe_output.status_code)
+
+    def test_not_user_arg(self):
+        """Test the pipeline method doesnt receive user
+        Expected behavior:
+            - The pipe method returns None
+        """
+
+        pipe_output = disallow_staff_superuser_users(self.request, self.backend, self.details, self.response)
+
+        self.assertIsNone(pipe_output)

--- a/eox_nelp/third_party_auth/utils.py
+++ b/eox_nelp/third_party_auth/utils.py
@@ -1,0 +1,36 @@
+"""Utils module to dont repeat code."""
+import logging
+
+from django.core.exceptions import MultipleObjectsReturned
+
+logger = logging.getLogger(__name__)
+
+
+def match_user_using_uid_query(backend, response, user_query):
+    """Look up for a user using query to match uid.
+    The uid is based in the configuration of the saml with the field `attr_user_permanent_id`:
+    https://github.com/python-social-auth/social-core/blob/master/social_core/backends/saml.py#L49
+
+    This is using the idp and the uid inspired in:
+    https://github.com/python-social-auth/social-core/blob/master/social_core/backends/saml.py#L296C23-L297
+    Args:
+        backend (backend): backend to use strategy to get user model
+        response (dict): Response Dict
+        user_query (str): string query to find the user.
+    Returns:
+        user_match(User): User matched object or None
+    """
+    user_match = None
+    idp = backend.get_idp(response["idp_name"])
+    uid = idp.get_user_permanent_id(response["attributes"])
+    try:
+        user_match = backend.strategy.storage.user.get_user(**{user_query: uid})
+    except MultipleObjectsReturned as exc:
+        logger.info(
+            "Pipeline tries to match user with uid(%s) using %s, but Multiple users found: %s",
+            uid,
+            user_query,
+            str(exc),
+        )
+
+    return user_match


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

As username was changed as national_id, now the national_id needs to be
loaded using other fields.
eg `uid=1999444333`
So now user is looked up using:
- safer_associate_user_by_national_id: extrainfo__national_id
- safer_associate_user_by_social_auth_record: social_auth__uid__endswith

Also there is other pipe that was separated to manage staff and superusers.
- disallow_staff_superuser_users

## Testing instructions
We need to change the pipelines functions in this way.
### Before
```
SOCIAL_AUTH_TPA_SAML_PIPELINE = [
...
    "eox_nelp.third_party_auth.pipeline.safer_associate_username_by_uid",
...
]
```
### After
```
SOCIAL_AUTH_TPA_SAML_PIPELINE = [
...
    "eox_nelp.third_party_auth.pipeline.safer_associate_user_by_national_id",
    "eox_nelp.third_party_auth.pipeline.safer_associate_user_by_social_auth_record",
    "eox_nelp.third_party_auth.pipeline.disallow_staff_superuser_users",
...
]
```
Check if saml association are working =)
## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
