### PR TITLE
feat: create a new pipeline step that validates the national id base …

### DIFF
--- a/eox_nelp/third_party_auth/pipeline.py
+++ b/eox_nelp/third_party_auth/pipeline.py
@@ -4,6 +4,8 @@ functions:
     social_details: Allows to map response fields to user standard fields.
     invalidate_current_user: Sets to None the current user.
 """
+import logging
+
 from django.conf import settings
 from django.contrib.auth import logout
 from django.http import HttpResponseForbidden
@@ -14,6 +16,8 @@ from social_core.pipeline.social_auth import social_details as social_core_detai
 
 from eox_nelp.edxapp_wrapper.edxmako import edxmako
 from eox_nelp.third_party_auth.utils import match_user_using_uid_query
+
+logger = logging.getLogger(__name__)
 
 
 def social_details(backend, details, response, *args, **kwargs):
@@ -169,6 +173,11 @@ def validate_national_id_and_associate_user(request, backend, uid, *args, user=N
     if national_id and uid.endswith(national_id):
         return associate_user(backend, uid, user, social, *args, **kwargs)
 
+    logger.warning(
+        "User association failed: UID does not end with the user's national ID. UID: %s, National ID: %s",
+        uid,
+        national_id,
+    )
     logout(request)
 
     return redirect("/register")

--- a/eox_nelp/third_party_auth/pipeline.py
+++ b/eox_nelp/third_party_auth/pipeline.py
@@ -7,7 +7,9 @@ functions:
 from django.conf import settings
 from django.contrib.auth import logout
 from django.http import HttpResponseForbidden
+from django.shortcuts import redirect
 from django.utils.translation import gettext_lazy as _
+from social_core.pipeline.social_auth import associate_user
 from social_core.pipeline.social_auth import social_details as social_core_details
 
 from eox_nelp.edxapp_wrapper.edxmako import edxmako
@@ -143,3 +145,30 @@ def disallow_staff_superuser_users(  # pylint: disable=unused-argument
             )
         )
     return {}
+
+
+def validate_national_id_and_associate_user(request, backend, uid, *args, user=None, social=None, **kwargs):
+    """
+    Validates the user's national ID against the provided SAML UID before associating
+    a SAML identity with a Django user. If validation fails, the session is ended, and
+    the user is redirected to registration.
+
+    Args:
+        request (HttpRequest): The HTTP request object.
+        backend: The authentication backend used, such as SAML.
+        uid (str): Unique identifier from SAML (e.g., user ID).
+        user (User, optional): Django user instance, if found.
+        social (optional): Existing social authentication data, if found.
+
+    Returns:
+        If the UID validation succeeds, proceeds to associate the user with social auth.
+        Otherwise, logs out the current session and redirects to the registration page.
+    """
+    national_id = user.extrainfo.national_id if user and hasattr(user, "extrainfo") else ""
+
+    if national_id and uid.endswith(national_id):
+        return associate_user(backend, uid, user, social, *args, **kwargs)
+
+    logout(request)
+
+    return redirect("/register")


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This pull request introduces the validate_national_id_and_associate_user pipeline method, designed to improve user association logic in SAML authentication flows. This method verifies that a user's UID from the identity provider ends with their registered national ID. If a match is found, it securely associates the user without altering their session. If there is no match, or if the national ID is absent, the method triggers a logout and redirects the user to the registration page, ensuring only properly identified users are associated.

Key improvements include:

1. Ensuring accurate user associations by verifying the UID-national ID suffix match.
2. Automatically handling sessions by logging out mismatched users to enhance security.
3. Streamlining user onboarding with an immediate redirect to the registration page if the national ID is not present.

## Testing instructions
This requires the following settings

```python
REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES = ["arabic_name", "national_id"]
REGISTRATION_EXTRA_FIELDS = {
    ...
    "national_id": "required",
    ...
}
```
Replace `"social_core.pipeline.social_auth.associate_user"` with `"eox_nelp.third_party_auth.pipeline.validate_national_id_and_associate_user",` in `SOCIAL_AUTH_TPA_SAML_PIPELINE`


![image](https://github.com/user-attachments/assets/954577fd-075f-49ac-b07d-bc6ccceb19f8)
![image](https://github.com/user-attachments/assets/20b65cd3-d8de-4501-8fd1-e8418cda9644)

Finally register a new user with SAML


<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
