### PR TITLE
fix: upgrade github action cache version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache dependency
-        uses: actions/cache@v3.2.3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements/test.txt') }}


### PR DESCRIPTION
## Description
This PR upgrades the Github cache action version from `v3.2.3` to `v4`.