### PR TITLE
Jlc/pin nelc api clients

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -27,4 +27,4 @@ social-auth-app-django
 tincan
 xmltodict==0.13.0
 git+ssh://git@github.com/nelc/nelp-custom-registration-fields.git@main
-git+ssh://git@github.com/nelc/external-api-clients.git@main
+git+ssh://git@github.com/nelc/external-api-clients.git@v0.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -212,7 +212,7 @@ event-tracking==3.0.0
     # via
     #   -r requirements/base.in
     #   edx-proctoring
-external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@main
+external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@v0.1.0
     # via -r requirements/base.in
 fastavro==1.10.0
     # via openedx-events

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -289,7 +289,7 @@ event-tracking==3.0.0
     # via
     #   -r /home/johanc/nelp/test/eox-nelp/requirements/base.txt
     #   edx-proctoring
-external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@main
+external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@v0.1.0
     # via -r /home/johanc/nelp/test/eox-nelp/requirements/base.txt
 fastavro==1.10.0
     # via


### PR DESCRIPTION
# Description

[feat: pin nelc api client to v0.1.0]

This is for not breaking API_clients due to the new changes in 'main' of the nelc_api_clients library.
