### PR TITLE
feat: add full name attribute to pearson vue request

### DIFF
--- a/eox_nelp/pearson_vue/tests/test_utils.py
+++ b/eox_nelp/pearson_vue/tests/test_utils.py
@@ -579,13 +579,12 @@ class TestGetUserData(TestCase):
         """
         self.user = MagicMock(
             username="testuser",
-            full_name="Test User",
             first_name="Test",
             last_name="User",
             email="test@example.com",
             profile=MagicMock(
                 country=MagicMock(code="US"),
-
+                name="Test User",
                 city="Test City",
                 phone_number="123-456-7890",
                 mailing_address="123 Test St",
@@ -607,6 +606,7 @@ class TestGetUserData(TestCase):
         """
         expected_result = {
             "username": self.user.username,
+            "full_name": self.user.profile.name,
             "first_name": self.user.first_name,
             "last_name": self.user.last_name,
             "email": self.user.email,

--- a/eox_nelp/pearson_vue/utils.py
+++ b/eox_nelp/pearson_vue/utils.py
@@ -81,6 +81,7 @@ def get_user_data(user):
     """
     user_data = {
         "username": user.username,
+        "full_name": user.profile.name,
         "first_name": user.first_name,
         "last_name": user.last_name,
         "email": user.email,


### PR DESCRIPTION
## Description
This PR updates the `get_user_data` method to include the new `full_name` attribute.
**IMPORTANT** please take a look at #245, its changes are necessary for this feature to work correctly.

## Changes:
- Added the `full_name` attribute to the pearson vue engine request.
- Update the `get_user_data` unit tests.

## Testing
Did a recent request to pvengine stage to check it works correctly.

![image](https://github.com/user-attachments/assets/1e257c70-101a-4c92-8a32-f70f77b924b4)
