### PR TITLE
feat: add get validated user fields view

### DIFF
--- a/eox_nelp/user_profile/api/v1/urls.py
+++ b/eox_nelp/user_profile/api/v1/urls.py
@@ -1,10 +1,11 @@
-"""eox_nelp puser_profile.api v1 urls"""
+"""eox_nelp user_profile.api v1 urls"""
 from django.urls import path
 
-from eox_nelp.user_profile.api.v1.views import update_user_data
+from eox_nelp.user_profile.api.v1.views import get_validated_user_fields, update_user_data
 
 app_name = "eox_nelp"  # pylint: disable=invalid-name
 
 urlpatterns = [
     path("update-user-data/", update_user_data, name="update-user-data"),
+    path("validated-fields/", get_validated_user_fields, name="validated-fields"),
 ]


### PR DESCRIPTION
## Description

Adds a new view that allows to get field validation base on `REQUIRED_USER_FIELDS` setting

## Testing instructions
1. First the `REQUIRED_USER_FIELDS` setting
```
REQUIRED_USER_FIELDS = {
    "account": {
        "first_name": {"max_length": 30, "char_type": "latin"},
        "last_name": {"max_length": 50, "char_type": "latin"},
    },
    "profile": {
        "city": {"max_length": 32, "char_type": "latin"},
        "country": {"max_length": 2, "optional_values": ["US", "CA", "MX", "BR"]},
        "phone_number": {"max_length": 15, "format": "phone"},
        "mailing_address": {"max_length": 40},
    },
    "extra_info": {
        "arabic_name": {"max_length": 20, "char_type": "arabic"},
        "arabic_first_name": {"max_length": 20, "char_type": "arabic"},
        "arabic_last_name": {"max_length": 50, "char_type": "arabic"},
    },
}
```
2. Go to `/eox-nelp/api/user-profile/v1/validated-fields/`
3. Go to the admin panel and change the user attributes, set an invalid value, then repeat previous step

![image](https://github.com/user-attachments/assets/7f4968ea-f2f6-4d20-8c08-a24e4b52930e)

 

