### PR TITLE
feat: remove pylint useless suppressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 
 quality: clean install-test-reqs## check coding style with pycodestyle and pylint
 	$(TOX) pycodestyle ./eox_nelp
-	$(TOX) pylint ./eox_nelp --rcfile=./setup.cfg
+	$(TOX) pylint ./eox_nelp --rcfile=./setup.cfg --fail-on=I0021
 	$(TOX) isort --check-only --diff ./eox_nelp
 
 python-test: clean install-test-reqs## Run test suite.

--- a/eox_nelp/cms/api/urls.py
+++ b/eox_nelp/cms/api/urls.py
@@ -4,6 +4,6 @@ from django.urls import include, path
 
 app_name = "eox_nelp"  # pylint: disable=invalid-name
 
-urlpatterns = [  # pylint: disable=invalid-name
+urlpatterns = [
     path("v1/", include("eox_nelp.cms.api.v1.urls", namespace="v1"))
 ]

--- a/eox_nelp/cms/api/v1/tests/test_views.py
+++ b/eox_nelp/cms/api/v1/tests/test_views.py
@@ -41,7 +41,7 @@ class CMSCourseRunView(TestCase):
     """
     Test for cms Course Run  view.
     """
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """
         Set base variables and objects across experience test cases.
         """

--- a/eox_nelp/cms_urls.py
+++ b/eox_nelp/cms_urls.py
@@ -19,7 +19,7 @@ from eox_nelp import views
 
 app_name = 'eox_nelp'  # pylint: disable=invalid-name
 
-urlpatterns = [  # pylint: disable=invalid-name
+urlpatterns = [
     path('eox-info/', views.info_view, name='eox-info'),
     path('api/', include('eox_nelp.cms.api.urls', namespace='cms-api')),
 

--- a/eox_nelp/course_api/urls.py
+++ b/eox_nelp/course_api/urls.py
@@ -4,6 +4,6 @@ from django.urls import include, path
 
 app_name = 'eox_nelp'  # pylint: disable=invalid-name
 
-urlpatterns = [  # pylint: disable=invalid-name
+urlpatterns = [
     path('v1/', include('eox_nelp.course_api.v1.urls', namespace='v1')),
 ]

--- a/eox_nelp/course_api/v1/serializers.py
+++ b/eox_nelp/course_api/v1/serializers.py
@@ -9,7 +9,7 @@ from eox_nelp.edxapp_wrapper.course_api import CourseDetailSerializer
 from eox_nelp.edxapp_wrapper.course_experience import course_home_url as retrieve_course_home_url
 
 
-class NelpCourseDetailSerializer(CourseDetailSerializer):  # pylint: disable=abstract-method
+class NelpCourseDetailSerializer(CourseDetailSerializer):
     """
     Serializer for Course objects providing additional details about the
     course.

--- a/eox_nelp/course_api/v1/tests/test_views.py
+++ b/eox_nelp/course_api/v1/tests/test_views.py
@@ -22,7 +22,7 @@ User = get_user_model()
 class NelpCoursesApiViewsTestCase(APITestCase):
     """ Test Nelp Courses API views. """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """
         Set base variables and objects across experience test cases.
         """

--- a/eox_nelp/course_experience/api/urls.py
+++ b/eox_nelp/course_experience/api/urls.py
@@ -4,6 +4,6 @@ from django.urls import include, path
 
 app_name = "eox_nelp"  # pylint: disable=invalid-name
 
-urlpatterns = [  # pylint: disable=invalid-name
+urlpatterns = [
     path("v1/", include("eox_nelp.course_experience.api.v1.urls", namespace="v1"))
 ]

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -30,7 +30,7 @@ from rest_framework_json_api.metadata import JSONAPIMetadata
 from rest_framework_json_api.pagination import JsonApiPageNumberPagination
 from rest_framework_json_api.parsers import JSONParser
 from rest_framework_json_api.renderers import BrowsableAPIRenderer, JSONRenderer
-from rest_framework_json_api.schemas.openapi import AutoSchema  # pylint: disable=no-name-in-module,syntax-error
+from rest_framework_json_api.schemas.openapi import AutoSchema
 from rest_framework_json_api.views import ModelViewSet, ReadOnlyModelViewSet
 
 from eox_nelp.course_experience.models import (

--- a/eox_nelp/course_experience/frontend/tests/test_views.py
+++ b/eox_nelp/course_experience/frontend/tests/test_views.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIClient
 class FrontendFeedbackCourseTestCase(TestCase):
     """ Test FeedbackCoursesTemplate view """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """
         Set base variables and objects across experience test cases.
         """

--- a/eox_nelp/course_experience/frontend/views.py
+++ b/eox_nelp/course_experience/frontend/views.py
@@ -17,6 +17,6 @@ class FeedbackCoursesTemplate(View):
     General feedback courses template.
     """
 
-    def get(self, request):  # pylint: disable=unused-argument
+    def get(self, request):
         """Render start html"""
         return edxmako.shortcuts.render_to_response("feedback_carousel/index.html", {}, "main", request)

--- a/eox_nelp/init_pipeline.py
+++ b/eox_nelp/init_pipeline.py
@@ -28,7 +28,7 @@ def patch_user_gender_choices():
     """
     This overwrites the available gender choices in order to allow the Male and Female options.
     """
-    # pylint: disable=import-error, import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     # This cannot be at the top of the file since this file is imported the plugin initialization
     # and therefore the settings has not been set yet
     from eox_nelp.edxapp_wrapper.student import UserProfile
@@ -41,7 +41,7 @@ def patch_user_gender_choices():
 
 def set_mako_templates():
     """This method adds the plugin templates to mako configuration."""
-    # pylint: disable=import-error, import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     # This cannot be at the top of the file since this file is imported on the plugin initialization
     # and therefore the settings has not been set yet
     from eox_nelp import static as static_module
@@ -68,7 +68,7 @@ def register_xapi_transformers():
 
 def update_permissions():
     """This method just change permissions for bussiness cases"""
-    # pylint: disable=import-outside-toplevel,unsupported-binary-operation
+    # pylint: disable=import-outside-toplevel
     from bridgekeeper import perms
     from bridgekeeper.rules import is_staff
 
@@ -88,7 +88,7 @@ def patch_generate_password():
     """This method patch `generate_password` of edx_django_util package,
     with custom nelp `generate_password`.
     """
-    # pylint: disable=import-outside-toplevel, unused-import
+    # pylint: disable=import-outside-toplevel
     from eox_tenant.tenant_wise import set_as_proxy
 
     from eox_nelp.user_authn.utils import generate_password
@@ -109,7 +109,7 @@ def patch_registration_form_factory():
     """This method patches `RegistrationFormFactory` of user_auth.view.registration_form ,
     with custom nelp `NelpRegistrationFormFactory`.
     """
-    # pylint: disable=import-outside-toplevel, unused-import
+    # pylint: disable=import-outside-toplevel
     from eox_nelp.edxapp_wrapper.user_authn import views
     from eox_nelp.user_authn.views.registration_form import NelpRegistrationFormFactory
     views.registration_form.RegistrationFormFactory = NelpRegistrationFormFactory

--- a/eox_nelp/init_pipeline.py
+++ b/eox_nelp/init_pipeline.py
@@ -77,7 +77,7 @@ def update_permissions():
 
     perms.pop(permissions.CAN_RESEARCH, None)
     perms[permissions.CAN_RESEARCH] = (
-        is_staff
+        is_staff  # pylint: disable=unsupported-binary-operation, useless-suppression
         | rules.HasRolesRule("data_researcher")
         | rules.HasAccessRule("staff")
         | rules.HasAccessRule("instructor")

--- a/eox_nelp/management/commands/notify_course_due_dates.py
+++ b/eox_nelp/management/commands/notify_course_due_dates.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     """Class command to check course due dates and also notify the corresponding."""
-    def handle(self, *args, **options):  # lint-amnesty, pylint: disable=too-many-statements
+    def handle(self, *args, **options):  # lint-amnesty
 
         logger.info('----Checking course due dates emails by command.-----')
         now = timezone.now()

--- a/eox_nelp/management/commands/tests/test_check_notify_course_due_dates.py
+++ b/eox_nelp/management/commands/tests/test_check_notify_course_due_dates.py
@@ -19,7 +19,7 @@ class CheckNotifyCourseDueDateTestCase(TestCase):
     """ Test `check notify_course_due_dates` command. """
     # pylint: disable=no-member
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """
         Set base variables and objects across UpcomingCourseDueDate test cases.
         """

--- a/eox_nelp/one_time_password/api/urls.py
+++ b/eox_nelp/one_time_password/api/urls.py
@@ -3,6 +3,6 @@ from django.urls import include, path
 
 app_name = "eox_nelp"  # pylint: disable=invalid-name
 
-urlpatterns = [  # pylint: disable=invalid-name
+urlpatterns = [
     path("v1/", include("eox_nelp.one_time_password.api.v1.urls", namespace="v1"))
 ]

--- a/eox_nelp/one_time_password/api/v1/tests/test_views.py
+++ b/eox_nelp/one_time_password/api/v1/tests/test_views.py
@@ -174,7 +174,7 @@ class ValidateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
     """Test case for validate OTP view."""
     reverse_viewname = "one-time-password-api:v1:validate-otp"
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Clear cache after or mocks each test case. Clean extrainfo values."""
         cache.clear()
         ExtraInfo.objects.all().delete()  # pylint: disable=no-member

--- a/eox_nelp/openedx_filters/xapi/filters.py
+++ b/eox_nelp/openedx_filters/xapi/filters.py
@@ -223,7 +223,7 @@ class XApiContextFilter(PipelineStep):
         }
     """
 
-    def run_filter(self, transformer, result):  # pylint: disable=arguments-differ, unused-argument
+    def run_filter(self, transformer, result):  # pylint: disable=arguments-differ
         """This allows to modify the statement context for any event, the allowed modifications are
         limited by the tincan library and it's not possible to changed or updated all of them, the
         supported fields are the following:
@@ -376,7 +376,7 @@ class XApiCertificateContextFilter(PipelineStep):
         }
     """
 
-    def run_filter(self, transformer, result):  # pylint: disable=arguments-differ, unused-argument
+    def run_filter(self, transformer, result):  # pylint: disable=arguments-differ
         """This adds jws-certificate-location extension
 
         Arguments:

--- a/eox_nelp/payment_notifications/urls.py
+++ b/eox_nelp/payment_notifications/urls.py
@@ -7,6 +7,6 @@ from eox_nelp.payment_notifications.views import PaymentNotificationsView
 
 app_name = 'eox_nelp'  # pylint: disable=invalid-name
 
-urlpatterns = [  # pylint: disable=invalid-name
+urlpatterns = [
     path("", PaymentNotificationsView.as_view(), name="payment-notifications"),
 ]

--- a/eox_nelp/pearson_vue/api/urls.py
+++ b/eox_nelp/pearson_vue/api/urls.py
@@ -7,6 +7,6 @@ from django.urls import include, path
 
 app_name = 'eox_nelp'  # pylint: disable=invalid-name
 
-urlpatterns = [  # pylint: disable=invalid-name
+urlpatterns = [
     path('v1/', include('eox_nelp.pearson_vue.api.v1.urls', namespace='v1')),
 ]

--- a/eox_nelp/pearson_vue/tests/test_pipeline.py
+++ b/eox_nelp/pearson_vue/tests/test_pipeline.py
@@ -112,7 +112,7 @@ class TestGetUserData(unittest.TestCase):
         setattr(User, "profile", self.profile)
         setattr(User, "extrainfo", self.extrainfo)
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Reset mocks"""
         anonymous_id_for_user.reset_mock()
         delattr(User, "extrainfo")

--- a/eox_nelp/pearson_vue/utils.py
+++ b/eox_nelp/pearson_vue/utils.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from pydantic.v1.utils import deep_update
 
 from eox_nelp.edxapp_wrapper.student import AnonymousUserId, CourseEnrollment, anonymous_id_for_user
-from eox_nelp.pearson_vue.models import PearsonEngine  # pylint: disable=import-outside-toplevel
+from eox_nelp.pearson_vue.models import PearsonEngine
 
 
 def update_xml_with_dict(xml: str, update_dict: dict) -> str:

--- a/eox_nelp/stats/api/urls.py
+++ b/eox_nelp/stats/api/urls.py
@@ -4,6 +4,6 @@ from django.urls import include, path
 
 app_name = "eox_nelp"  # pylint: disable=invalid-name
 
-urlpatterns = [  # pylint: disable=invalid-name
+urlpatterns = [
     path("v1/", include("eox_nelp.stats.api.v1.urls", namespace="v1")),
 ]

--- a/eox_nelp/stats/tests/test_views.py
+++ b/eox_nelp/stats/tests/test_views.py
@@ -15,7 +15,7 @@ from eox_nelp.stats.views import STATS_QUERY_PARAMS
 class GetTenantStatsTestCase(TestCase):
     """ Test get_tenant_stats function based view."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """
         Set base variables and objects across experience test cases.
         """

--- a/eox_nelp/stats/tests/tests_metrics.py
+++ b/eox_nelp/stats/tests/tests_metrics.py
@@ -184,7 +184,7 @@ class TestGetCoursesMetrics(unittest.TestCase):
 class TestGetCourseMetrics(unittest.TestCase):
     """Tests cases for get_courses_metrics function."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """
         Set base variables and objects across metrics test cases.
         """

--- a/eox_nelp/urls.py
+++ b/eox_nelp/urls.py
@@ -19,7 +19,7 @@ from eox_nelp import views
 
 app_name = 'eox_nelp'  # pylint: disable=invalid-name
 
-urlpatterns = [  # pylint: disable=invalid-name
+urlpatterns = [
     path('eox-info/', views.info_view, name='eox-info'),
     path('courses/', include('eox_nelp.course_api.urls', namespace='nelp-course-api')),
     path('api/mfe_config/', include('eox_nelp.mfe_config_api.urls', namespace='mfe-config-api')),

--- a/eox_nelp/user_profile/api/urls.py
+++ b/eox_nelp/user_profile/api/urls.py
@@ -3,6 +3,6 @@ from django.urls import include, path
 
 app_name = "eox_nelp"  # pylint: disable=invalid-name
 
-urlpatterns = [  # pylint: disable=invalid-name
+urlpatterns = [
     path("v1/", include("eox_nelp.user_profile.api.v1.urls", namespace="v1"))
 ]

--- a/eox_nelp/user_profile/api/v1/tests/test_views.py
+++ b/eox_nelp/user_profile/api/v1/tests/test_views.py
@@ -24,7 +24,7 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
     """Test case for update user data view."""
     reverse_viewname = "user-profile-api:v1:update-user-data"
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def tearDown(self):
         """Reset Mocks"""
         accounts.reset_mock()
         accounts.api.update_account_settings.side_effect = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,5 +47,6 @@ max-line-length = 120
 disable =
 	too-few-public-methods, #R0903,
 	too-many-ancestors, #R0901,
+enable = useless-suppression
 
 [bumpversion:file:eox_nelp/__init__.py]


### PR DESCRIPTION
## Description
This PR enables the [Pylint's useless suppression validation](https://pylint.readthedocs.io/en/v3.3.3/user_guide/messages/information/useless-suppression.html).  This rule reports when a message is explicitly disabled for a line or a block of code, but never triggered.  It was implemented as shown in Pylint's docs.

## Changes
- Remove any unused validations suppressed through the entire project in f978201
- Change the `makefile` and `setup.cfg` for further validations in bfbc460

## Testing
After locally executing `make quality` changes seems to be ok.

![image](https://github.com/user-attachments/assets/584974d3-8636-4764-a65a-fb031a359edb)


>[!NOTE]
>
>Even though multiple files were affected, I only removed the useless suppressions; no major changes were applied.
