### PR TITLE
feat: unpin external-api-clients package

### DIFF
--- a/eox_nelp/one_time_password/api/v1/tests/test_views.py
+++ b/eox_nelp/one_time_password/api/v1/tests/test_views.py
@@ -43,7 +43,10 @@ class GenerateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
         self.assertDictEqual(response.json(), {"detail": "missing phone_number in data."})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    @override_settings(SMS_VENDOR_SEND_SMS_PATH="/test/sms/path")
+    @override_settings(
+        SMS_VENDOR_SEND_SMS_PATH="/test/sms/path",
+        SMS_VENDOR_BASE_URL="http://test-sms-vendor.com",
+    )
     @patch("eox_nelp.one_time_password.api.v1.views.SMSVendorApiClient")
     def test_generate_otp(self, sms_vendor_mock):
         """
@@ -86,7 +89,10 @@ class GenerateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
             "/test/sms/path"
         )
 
-    @override_settings(SMS_VENDOR_SEND_SMS_PATH="/test/sms/path")
+    @override_settings(
+        SMS_VENDOR_SEND_SMS_PATH="/test/sms/path",
+        SMS_VENDOR_BASE_URL="http://test-sms-vendor.com",
+    )
     @patch("eox_nelp.one_time_password.api.v1.views.SMSVendorApiClient")
     def test_generate_otp_fails_sms_vendor(self, sms_vendor_mock):
         """
@@ -126,7 +132,8 @@ class GenerateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
         PHONE_VALIDATION_OTP_LENGTH=20,
         PHONE_VALIDATION_OTP_CHARSET="01",
         PHONE_VALIDATION_OTP_TIMEOUT=1200,
-        SMS_VENDOR_SEND_SMS_PATH="/test/sms/path"
+        SMS_VENDOR_SEND_SMS_PATH="/test/sms/path",
+        SMS_VENDOR_BASE_URL="http://test-sms-vendor.com",
     )
     @patch("eox_nelp.one_time_password.api.v1.views.SMSVendorApiClient")
     def test_generate_otp_custom_settings(self, sms_vendor_mock):

--- a/eox_nelp/one_time_password/api/v1/tests/test_views.py
+++ b/eox_nelp/one_time_password/api/v1/tests/test_views.py
@@ -43,6 +43,7 @@ class GenerateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
         self.assertDictEqual(response.json(), {"detail": "missing phone_number in data."})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @override_settings(SMS_VENDOR_SEND_SMS_PATH="/test/sms/path")
     @patch("eox_nelp.one_time_password.api.v1.views.SMSVendorApiClient")
     def test_generate_otp(self, sms_vendor_mock):
         """
@@ -82,8 +83,10 @@ class GenerateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
         sms_vendor_mock().send_sms.assert_called_with(
             payload['phone_number'],
             f"Futurex Phone Validation Code: {otp_stored}",
+            "/test/sms/path"
         )
 
+    @override_settings(SMS_VENDOR_SEND_SMS_PATH="/test/sms/path")
     @patch("eox_nelp.one_time_password.api.v1.views.SMSVendorApiClient")
     def test_generate_otp_fails_sms_vendor(self, sms_vendor_mock):
         """
@@ -116,12 +119,14 @@ class GenerateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
         sms_vendor_mock().send_sms.assert_called_with(
             payload['phone_number'],
             f"Futurex Phone Validation Code: {otp_stored}",
+            "/test/sms/path"
         )
 
     @override_settings(
         PHONE_VALIDATION_OTP_LENGTH=20,
         PHONE_VALIDATION_OTP_CHARSET="01",
         PHONE_VALIDATION_OTP_TIMEOUT=1200,
+        SMS_VENDOR_SEND_SMS_PATH="/test/sms/path"
     )
     @patch("eox_nelp.one_time_password.api.v1.views.SMSVendorApiClient")
     def test_generate_otp_custom_settings(self, sms_vendor_mock):
@@ -166,6 +171,7 @@ class GenerateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
         sms_vendor_mock().send_sms.assert_called_with(
             payload['phone_number'],
             f"Futurex Phone Validation Code: {otp_stored}",
+            "/test/sms/path"
         )
 
 

--- a/eox_nelp/one_time_password/api/v1/views.py
+++ b/eox_nelp/one_time_password/api/v1/views.py
@@ -62,10 +62,10 @@ def generate_otp(request):
     logger.info("generating otp %s*****", user_otp_key[:-5])
     cache.set(user_otp_key, otp, timeout=getattr(settings, "PHONE_VALIDATION_OTP_TIMEOUT", 600))
     sms_client = SMSVendorApiClient(
-        user=getattr(settings, "SMS_VENDOR_USERNAME", ""),
-        password=getattr(settings, "SMS_VENDOR_PASSWORD", ""),
-        token_path=getattr(settings, "SMS_VENDOR_TOKEN_PATH", ""),
-        base_url=getattr(settings, "SMS_VENDOR_BASE_URL", "")
+        user=settings.SMS_VENDOR_USERNAME,
+        password=settings.SMS_VENDOR_PASSWORD,
+        token_path=settings.SMS_VENDOR_TOKEN_PATH,
+        base_url=settings.SMS_VENDOR_BASE_URL,
     )
 
     path = getattr(settings, "SMS_VENDOR_SEND_SMS_PATH", "")

--- a/eox_nelp/one_time_password/api/v1/views.py
+++ b/eox_nelp/one_time_password/api/v1/views.py
@@ -61,7 +61,16 @@ def generate_otp(request):
     user_otp_key = f"{request.user.username}-{user_phone_number}"
     logger.info("generating otp %s*****", user_otp_key[:-5])
     cache.set(user_otp_key, otp, timeout=getattr(settings, "PHONE_VALIDATION_OTP_TIMEOUT", 600))
-    sms_vendor_response = SMSVendorApiClient().send_sms(user_phone_number, f"Futurex Phone Validation Code: {otp}")
+    sms_client = SMSVendorApiClient(
+        user=getattr(settings, "SMS_VENDOR_USERNAME", ""),
+        password=getattr(settings, "SMS_VENDOR_PASSWORD", ""),
+        token_path=getattr(settings, "SMS_VENDOR_TOKEN_PATH", ""),
+        base_url=getattr(settings, "SMS_VENDOR_BASE_URL", "")
+    )
+
+    path = getattr(settings, "SMS_VENDOR_SEND_SMS_PATH", "")
+    otp_message = f"Futurex Phone Validation Code: {otp}"
+    sms_vendor_response = sms_client.send_sms(user_phone_number, otp_message, path)
 
     if "error" in sms_vendor_response:
         return JsonResponse(

--- a/eox_nelp/pearson_vue_engine/tasks.py
+++ b/eox_nelp/pearson_vue_engine/tasks.py
@@ -6,6 +6,7 @@ Tasks:
         Performs an asynchronous call to the Pearson Engine API to execute a real-time import action.
 """
 from celery import shared_task
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from nelc_api_clients.clients.pearson_engine import PearsonEngineApiClient
 from requests import exceptions
@@ -57,7 +58,12 @@ def real_time_import_task_v2(user_id, exam_id=None, action_name="rti", **kwargs)
     def audit_pearson_engine_action(user_id, exam_id, action_key, **kwargs):
         user = User.objects.get(id=user_id)
         update_user_engines(user, action_name, exam_id)
-        action = getattr(PearsonEngineApiClient(), action_key)
+        client = PearsonEngineApiClient(
+            client_id=settings.PEARSON_ENGINE_API_CLIENT_ID,
+            client_secret=settings.PEARSON_ENGINE_API_CLIENT_SECRET,
+            base_url=settings.PEARSON_ENGINE_API_URL,
+        )
+        action = getattr(client, action_key)
         parameters = generate_action_parameters(user, exam_id)
         response = action(**parameters, **kwargs)
 

--- a/eox_nelp/signals/tasks.py
+++ b/eox_nelp/signals/tasks.py
@@ -61,9 +61,9 @@ def _post_futurex_progress(data):
         data (dict): dict to send to futurex enrollment-progress path.
     """
     api_client = FuturexApiClient(
-        client_id=getattr(settings, "FUTUREX_CLIENT_ID"),
-        client_secret=getattr(settings, "FUTUREX_CLIENT_SECRET"),
-        base_url=getattr(settings, "FUTUREX_API_URL"),
+        client_id=settings.FUTUREX_CLIENT_ID,
+        client_secret=settings.FUTUREX_CLIENT_SECRET,
+        base_url=settings.FUTUREX_API_URL,
     )
     response = api_client.send_enrollment_progress(data)
 
@@ -143,10 +143,10 @@ def create_external_certificate(external_certificate_data):
             and will provide of the user certificate data.
     """
     api_client = ExternalCertificatesApiClient(
-        user=getattr(settings, "EXTERNAL_CERTIFICATES_USER"),
-        password=getattr(settings, "EXTERNAL_CERTIFICATES_PASSWORD"),
-        base_url=getattr(settings, "EXTERNAL_CERTIFICATES_API_URL"),
-        extra_headers=getattr(settings, "EXTERNAL_CERTIFICATES_EXTRA_HEADERS", {}),
+        user=settings.EXTERNAL_CERTIFICATES_USER,
+        password=settings.EXTERNAL_CERTIFICATES_PASSWORD,
+        base_url=settings.EXTERNAL_CERTIFICATES_API_URL,
+        extra_headers=settings.EXTERNAL_CERTIFICATES_EXTRA_HEADERS,
     )
     response = api_client.create_external_certificate(external_certificate_data)
 
@@ -217,9 +217,9 @@ def update_mt_training_stage(course_id, national_id, stage_result):
         stage_result (int): Representation of pass or fail result, 1 for pass  2 for fail.
     """
     api_client = MinisterOfTourismApiClient(
-        user=getattr(settings, "MINISTER_OF_TOURISM_USER"),
-        password=getattr(settings, "MINISTER_OF_TOURISM_PASSWORD"),
-        base_url=getattr(settings, "MINISTER_OF_TOURISM_API_URL"),
+        user=settings.MINISTER_OF_TOURISM_USER,
+        password=settings.MINISTER_OF_TOURISM_PASSWORD,
+        base_url=settings.MINISTER_OF_TOURISM_API_URL,
     )
 
     api_client.update_training_stage(

--- a/eox_nelp/signals/tasks.py
+++ b/eox_nelp/signals/tasks.py
@@ -216,7 +216,11 @@ def update_mt_training_stage(course_id, national_id, stage_result):
         national_id (str): User identifier.
         stage_result (int): Representation of pass or fail result, 1 for pass  2 for fail.
     """
-    api_client = MinisterOfTourismApiClient()
+    api_client = MinisterOfTourismApiClient(
+        user=getattr(settings, "MINISTER_OF_TOURISM_USER"),
+        password=getattr(settings, "MINISTER_OF_TOURISM_PASSWORD"),
+        base_url=getattr(settings, "MINISTER_OF_TOURISM_API_URL"),
+    )
 
     api_client.update_training_stage(
         course_id=course_id,

--- a/eox_nelp/signals/tasks.py
+++ b/eox_nelp/signals/tasks.py
@@ -138,7 +138,12 @@ def create_external_certificate(external_certificate_data):
             https://github.com/eduNEXT/openedx-events/blob/main/openedx_events/learning/data.py#L100
             and will provide of the user certificate data.
     """
-    api_client = ExternalCertificatesApiClient()
+    api_client = ExternalCertificatesApiClient(
+        user=getattr(settings, "EXTERNAL_CERTIFICATES_USER"),
+        password=getattr(settings, "EXTERNAL_CERTIFICATES_PASSWORD"),
+        base_url=getattr(settings, "EXTERNAL_CERTIFICATES_API_URL"),
+        extra_headers=getattr(settings, "EXTERNAL_CERTIFICATES_EXTRA_HEADERS", {}),
+    )
     response = api_client.create_external_certificate(external_certificate_data)
 
     logger.info(

--- a/eox_nelp/signals/tasks.py
+++ b/eox_nelp/signals/tasks.py
@@ -60,7 +60,11 @@ def _post_futurex_progress(data):
     Args:
         data (dict): dict to send to futurex enrollment-progress path.
     """
-    api_client = FuturexApiClient()
+    api_client = FuturexApiClient(
+        client_id=getattr(settings, "FUTUREX_CLIENT_ID"),
+        client_secret=getattr(settings, "FUTUREX_CLIENT_SECRET"),
+        base_url=getattr(settings, "FUTUREX_API_URL"),
+    )
     response = api_client.send_enrollment_progress(data)
 
     logger.info(

--- a/eox_nelp/signals/tests/test_tasks.py
+++ b/eox_nelp/signals/tests/test_tasks.py
@@ -135,6 +135,12 @@ class PostFuturexProgressTestCase(unittest.TestCase):
     """Test class for function `_post_futurex_progress`"""
 
     @patch("eox_nelp.signals.tasks.FuturexApiClient")
+    @override_settings(
+        FUTUREX_CLIENT_ID="test-client-id",
+        FUTUREX_CLIENT_SECRET="test-client-secret",
+        FUTUREX_TOKEN_URL="test-token-url",
+        FUTUREX_API_BASE_URL="test-api-base-url"
+    )
     def test_dispatch_futurex_progress(self, futurex_api_client_mock):
         """Test when `_post_futurex_progress` is called
         with the required parameters. Check the functions inside are called with

--- a/eox_nelp/signals/tests/test_tasks.py
+++ b/eox_nelp/signals/tests/test_tasks.py
@@ -362,6 +362,7 @@ class GenerateProgressEnrollmentDataTestCase(unittest.TestCase):
 class CreateExternalCertificateTestCase(unittest.TestCase):
     """Test class for create_external_certificate function"""
 
+    @override_settings(EXTERNAL_CERTIFICATES_EXTRA_HEADERS={"Authorization": "Bearer test-token"})
     @patch("eox_nelp.signals.tasks.ExternalCertificatesApiClient")
     def test_certificate_creation(self, api_mock):
         """Test standard call with the required parameters.

--- a/eox_nelp/signals/tests/test_tasks.py
+++ b/eox_nelp/signals/tests/test_tasks.py
@@ -139,7 +139,7 @@ class PostFuturexProgressTestCase(unittest.TestCase):
         FUTUREX_CLIENT_ID="test-client-id",
         FUTUREX_CLIENT_SECRET="test-client-secret",
         FUTUREX_TOKEN_URL="test-token-url",
-        FUTUREX_API_BASE_URL="test-api-base-url"
+        FUTUREX_API_BASE_URL="test-api-base-url",
     )
     def test_dispatch_futurex_progress(self, futurex_api_client_mock):
         """Test when `_post_futurex_progress` is called

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -28,4 +28,4 @@ social-auth-app-django
 tincan
 xmltodict==0.13.0
 git+ssh://git@github.com/nelc/nelp-custom-registration-fields.git@main
-git+ssh://git@github.com/nelc/external-api-clients.git@main
+git+ssh://git@github.com/nelc/external-api-clients.git@v1.0.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -28,4 +28,4 @@ social-auth-app-django
 tincan
 xmltodict==0.13.0
 git+ssh://git@github.com/nelc/nelp-custom-registration-fields.git@main
-git+ssh://git@github.com/nelc/external-api-clients.git@v0.1.0
+git+ssh://git@github.com/nelc/external-api-clients.git@main

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -215,7 +215,7 @@ event-tracking==3.0.0
     # via
     #   -r requirements/base.in
     #   edx-proctoring
-external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@v0.1.0
+external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@main
     # via -r requirements/base.in
 fastavro==1.10.0
     # via openedx-events

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -215,7 +215,7 @@ event-tracking==3.0.0
     # via
     #   -r requirements/base.in
     #   edx-proctoring
-external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@main
+external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@v1.0.0
     # via -r requirements/base.in
 fastavro==1.10.0
     # via openedx-events

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -292,7 +292,7 @@ event-tracking==3.0.0
     # via
     #   -r requirements/base.txt
     #   edx-proctoring
-external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@main
+external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@v1.0.0
     # via -r requirements/base.txt
 fastavro==1.10.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -292,7 +292,7 @@ event-tracking==3.0.0
     # via
     #   -r requirements/base.txt
     #   edx-proctoring
-external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@v0.1.0
+external-api-clients @ git+ssh://git@github.com/nelc/external-api-clients.git@main
     # via -r requirements/base.txt
 fastavro==1.10.0
     # via


### PR DESCRIPTION
## Description

This PR updates the external-api-clients package to the latest version. The upgrade required several adjustments to constructor calls throughout the codebase.

## Changes

* Unpinned external-api-clients package dependency
* Modified all of the clients constructor parameters to match the new required signature
* Added @override_settings decorators to provide required configuration in test environments
 

## How to test
### 1.Pearson engine api client
Follow the instructions from #249 for local setup. 
![pearson-engine-update-test](https://github.com/user-attachments/assets/b3c5b3ff-76cb-41fd-b67f-8c48c82d949d)


### 2. Pearson RTI api client
After completing a course an RTI request will be sended. 
![image](https://github.com/user-attachments/assets/babe9433-6773-4633-8956-ad5642f21d07)

The Badrequest response is enough to test the service call.