### PR TITLE
feat: ensure missing ExtraInfo fields are marked as empty instead of …

### DIFF
--- a/eox_nelp/user_profile/required_fields_validation.py
+++ b/eox_nelp/user_profile/required_fields_validation.py
@@ -64,6 +64,7 @@ REQUIRED_USER_FIELDS = {
 """
 import logging
 
+from custom_reg_form.models import ExtraInfo
 from django.conf import settings
 
 from eox_nelp.validators import validate_char_type, validate_format, validate_max_length, validate_optional_values
@@ -164,7 +165,13 @@ def validate_extra_info_fields(user, extra_info_fields):
     Returns:
         dict: A dictionary with invalid extra_info fields and their errors.
     """
-    return validate_user_fields(getattr(user, "extrainfo", None), extra_info_fields)
+    # pylint: disable=no-member
+    try:
+        extra_info = ExtraInfo.objects.get(user=user)
+    except ExtraInfo.DoesNotExist:
+        return {field: ["Empty field"] for field in extra_info_fields.keys() if hasattr(ExtraInfo, field)}
+
+    return validate_user_fields(extra_info, extra_info_fields)
 
 
 def validate_user_fields(instance, fields):


### PR DESCRIPTION
## Description
If the user doesn't have extrainfo the validation will return that al the required fields are missing

## How to test
1. Add settings
```python
REQUIRED_USER_FIELDS = {
    "account": {
        "first_name": {"max_length": 30, "char_type": "latin"},
        "last_name": {"max_length": 50, "char_type": "latin"},
        "invalid_field": {"max_length": 50, "char_type": "latin"},
    },
    "profile": {
        "city": {"max_length": 32, "char_type": "latin"},
        "country": {"max_length": 2, "optional_values": ["US", "CA", "MX", "BR"]},
        "phone_number": {"max_length": 15, "format": "phone"},
        "mailing_address": {"max_length": 40},
        "invalid_field": {"max_length": 50, "char_type": "latin"},
    },
    "extra_info": {
        "arabic_name": {"max_length": 20, "char_type": "arabic"},
        "arabic_first_name": {"max_length": 20, "char_type": "arabic"},
        "arabic_last_name": {"max_length": 50, "char_type": "arabic"},
        "national_id": {"max_length": 50,  "format": "numeric"},
        "invalid_field": {"max_length": 50, "char_type": "latin"},
    },
}
```
2. Go to `/eox-nelp/api/user-profile/v1/validated-fields/` when the user has extra info 
![image](https://github.com/user-attachments/assets/1ead0d6a-30b1-4fbe-8bb9-fba14cc5fd9e)

3. Go to `/eox-nelp/api/user-profile/v1/validated-fields/` when the user doesn't have extra info 
![image](https://github.com/user-attachments/assets/4895e3ed-1d04-4274-91fe-5327e8506cbc)
