### PR TITLE
feat: modify ExtraInfo saving to support multiple fields and enforce …

### DIFF
--- a/eox_nelp/one_time_password/api/v1/tests/test_views.py
+++ b/eox_nelp/one_time_password/api/v1/tests/test_views.py
@@ -191,7 +191,11 @@ class ValidateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
         """Overrides setUp behavior to add extrainfo attribute
         """
         super().setUp()
-        ExtraInfo.objects.get_or_create(user=self.user, arabic_name="مسؤل")  # pylint: disable=no-member
+        ExtraInfo.objects.get_or_create(  # pylint: disable=no-member
+            user=self.user,
+            arabic_name="مسؤل",
+            national_id="123457896",
+        )
 
     def tearDown(self):
         """Clear cache after or mocks each test case. Clean extrainfo values."""

--- a/eox_nelp/one_time_password/api/v1/tests/test_views.py
+++ b/eox_nelp/one_time_password/api/v1/tests/test_views.py
@@ -195,6 +195,7 @@ class ValidateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
             user=self.user,
             arabic_name="مسؤل",
             national_id="123457896",
+            occupation="student",
         )
 
     def tearDown(self):

--- a/eox_nelp/one_time_password/api/v1/tests/test_views.py
+++ b/eox_nelp/one_time_password/api/v1/tests/test_views.py
@@ -187,6 +187,12 @@ class ValidateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
     """Test case for validate OTP view."""
     reverse_viewname = "one-time-password-api:v1:validate-otp"
 
+    def setUp(self):
+        """Overrides setUp behavior to add extrainfo attribute
+        """
+        super().setUp()
+        ExtraInfo.objects.get_or_create(user=self.user, arabic_name="مسؤل")  # pylint: disable=no-member
+
     def tearDown(self):
         """Clear cache after or mocks each test case. Clean extrainfo values."""
         cache.clear()
@@ -265,19 +271,7 @@ class ValidateOTPTestCase(POSTAuthenticatedTestMixin, APITestCase):
             - Check everything from test `test_validate_right_otp_code`
             - extrainfo attr of user in is_phone_validated is True.
         """
-        self.user.extrainfo = ExtraInfo(is_phone_validated=False, arabic_name="فيدر")
         self.test_validate_right_otp_code()
 
-        self.assertTrue(self.user.extrainfo.is_phone_validated)
-
-    def test_validate_right_otp_code_without_extra_info(self):
-        """
-        Test the post request to validate otp with right data with a user with extrainfo foreign model.
-
-        Expected behavior:
-            - Check everything from test `test_validate_right_otp_code`
-            - extrainfo attr of user in is_phone_validated is True.
-        """
-        self.test_validate_right_otp_code()
-
+        self.user.extrainfo.refresh_from_db()
         self.assertTrue(self.user.extrainfo.is_phone_validated)

--- a/eox_nelp/one_time_password/view_decorators.py
+++ b/eox_nelp/one_time_password/view_decorators.py
@@ -12,7 +12,7 @@ from django.core.cache import cache
 from django.http import HttpResponseForbidden, JsonResponse
 from rest_framework import status
 
-from eox_nelp.utils import save_extrainfo_field
+from eox_nelp.utils import save_extrainfo
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ def validate_otp(func):
             if not proposed_user_otp == cache.get(user_otp_key):
                 return HttpResponseForbidden(reason="Forbidden - wrong code")
 
-            save_extrainfo_field(request.user, "is_phone_validated", True)
+            save_extrainfo(request.user, {"is_phone_validated": True})
             cache.delete(user_otp_key)
 
         return func(request)

--- a/eox_nelp/signals/tests/test_receivers.py
+++ b/eox_nelp/signals/tests/test_receivers.py
@@ -11,6 +11,7 @@ Classes:
 """
 import unittest
 
+from custom_reg_form.models import ExtraInfo
 from ddt import ddt
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
@@ -41,7 +42,6 @@ from eox_nelp.signals.receivers import (
     update_async_tracker_context,
 )
 from eox_nelp.tests.utils import set_key_values
-from eox_nelp.utils import save_extrainfo_field
 
 User = get_user_model()
 UserSignupSource = get_user_signup_source()
@@ -647,7 +647,11 @@ class MtCoursePassedHandlerTestCase(TestCase):
         """
         course_id = "course-v1:test+Cx105+2022_T4"
         user_instance, _ = User.objects.get_or_create(username="Severus")
-        save_extrainfo_field(user_instance, "national_id", "1234567890")
+        ExtraInfo.objects.get_or_create(  # pylint: disable=no-member
+            user=user_instance,
+            arabic_name="مسؤل",
+            national_id="12345445522",
+        )
 
         mt_course_passed_handler(user_instance, CourseKey.from_string(course_id))
 

--- a/eox_nelp/signals/tests/test_tasks.py
+++ b/eox_nelp/signals/tests/test_tasks.py
@@ -8,6 +8,7 @@ Classes:
 """
 import unittest
 
+from custom_reg_form.models import ExtraInfo
 from ddt import data, ddt
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -32,7 +33,6 @@ from eox_nelp.signals.tasks import (
 )
 from eox_nelp.signals.utils import get_completion_summary
 from eox_nelp.tests.utils import generate_list_mock_data
-from eox_nelp.utils import save_extrainfo_field
 
 User = get_user_model()
 FALSY_ACTIVATION_VALUES = [0, "", None, [], False, {}, ()]
@@ -626,7 +626,11 @@ class CourseCompletionMtUpdaterTestCase(TestCase):
             - mock validations pass
         """
         user_instance, _ = User.objects.get_or_create(username="Minerva")
-        save_extrainfo_field(user_instance, "national_id", "1234567890")
+        ExtraInfo.objects.get_or_create(  # pylint: disable=no-member
+            user=user_instance,
+            arabic_name="مسؤل",
+            national_id="12345445522",
+        )
         completion_summary_mock.return_value = {"incomplete_count": 0}
         self.descriptor.grading_policy = {"GRADER": test_data[0]}
 

--- a/eox_nelp/signals/tests/test_utils.py
+++ b/eox_nelp/signals/tests/test_utils.py
@@ -5,6 +5,7 @@ Classes:
 """
 import unittest
 
+from custom_reg_form.models import ExtraInfo
 from ddt import data, ddt
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -15,7 +16,6 @@ from opaque_keys.edx.keys import CourseKey
 from openedx_events.learning.data import CertificateData, CourseData, UserData, UserPersonalData
 
 from eox_nelp.signals.utils import _generate_external_certificate_data, _user_has_passing_grade
-from eox_nelp.utils import save_extrainfo_field
 
 User = get_user_model()
 
@@ -70,7 +70,11 @@ class GenerateExternalCertificateDataTestCase(TestCase):
             download_url="",
             name="",
         )
-        save_extrainfo_field(self.user, "national_id", "1234567890")
+        ExtraInfo.objects.get_or_create(  # pylint: disable=no-member
+            user=self.user,
+            arabic_name="مسؤل",
+            national_id="1234567890",
+        )
 
     @override_settings(EXTERNAL_CERTIFICATES_GROUP_CODES={"course-v1:test+Cx105+2022_T4": "ABC123"})
     @patch("eox_nelp.signals.utils._user_has_passing_grade")
@@ -95,7 +99,7 @@ class GenerateExternalCertificateDataTestCase(TestCase):
             "user": {
                 "national_id": self.user.extrainfo.national_id,
                 "english_name": self.certificate_data.user.pii.name,
-                "arabic_name": "",
+                "arabic_name": "مسؤل",
             }
         }
 
@@ -135,7 +139,11 @@ class GenerateExternalCertificateDataTestCase(TestCase):
         wrong_user, _ = User.objects.get_or_create(
             username="Albus",
         )
-        save_extrainfo_field(wrong_user, "national_id", wrong_national_id)
+        ExtraInfo.objects.get_or_create(  # pylint: disable=no-member
+            user=wrong_user,
+            arabic_name="مسؤل",
+            national_id=wrong_national_id,
+        )
         certificate_data = CertificateData(
             user=UserData(
                 pii=UserPersonalData(
@@ -188,7 +196,11 @@ class GenerateExternalCertificateDataTestCase(TestCase):
         saml_association_user, _ = User.objects.get_or_create(
             username="Severus",
         )
-        save_extrainfo_field(saml_association_user, "national_id", saml_extra_association)
+        ExtraInfo.objects.get_or_create(  # pylint: disable=no-member
+            user=saml_association_user,
+            arabic_name="مسؤل",
+            national_id=saml_extra_association,
+        )
         certificate_data = CertificateData(
             user=UserData(
                 pii=UserPersonalData(
@@ -220,7 +232,7 @@ class GenerateExternalCertificateDataTestCase(TestCase):
             "user": {
                 "national_id": national_id,
                 "english_name": certificate_data.user.pii.name,
-                "arabic_name": "",
+                "arabic_name": "مسؤل",
             }
         }
 

--- a/eox_nelp/tests/test_utils.py
+++ b/eox_nelp/tests/test_utils.py
@@ -251,6 +251,7 @@ class SaveExtraInfoTestCase(TestCase):
             "arabic_first_name": "أناكين",
             "arabic_last_name": "سكاي ووكر",
             "national_id": "1234512347",
+            "occupation": "student",
         }
 
         save_extrainfo(user, extrainfo_data)

--- a/eox_nelp/tests/test_utils.py
+++ b/eox_nelp/tests/test_utils.py
@@ -6,11 +6,12 @@ Classes:
 """
 from ddt import data, ddt
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
+from django.forms.models import model_to_dict
 from django.test import TestCase
 from mock import Mock, patch
 from opaque_keys.edx.keys import CourseKey
 
+from eox_nelp.edxapp_wrapper.user_api import errors
 from eox_nelp.utils import (
     camel_to_snake,
     extract_course_id_from_string,
@@ -249,12 +250,13 @@ class SaveExtraInfoTestCase(TestCase):
             "is_phone_validated": True,
             "arabic_first_name": "أناكين",
             "arabic_last_name": "سكاي ووكر",
+            "national_id": "1234512347",
         }
 
         save_extrainfo(user, extrainfo_data)
 
         self.assertEqual(
-            {field: value for field, value in user.extrainfo.__dict__.items() if field in extrainfo_data},
+            {field: value for field, value in model_to_dict(user.extrainfo).items() if field in extrainfo_data},
             extrainfo_data,
         )
 
@@ -285,5 +287,5 @@ class SaveExtraInfoTestCase(TestCase):
             "arabic_name": "english_name",
         }
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(errors.AccountValidationError):
             save_extrainfo(user, extrainfo_data)

--- a/eox_nelp/user_profile/api/v1/tests/test_views.py
+++ b/eox_nelp/user_profile/api/v1/tests/test_views.py
@@ -147,7 +147,13 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
 
     @override_settings(
         ENABLE_OTP_VALIDATION=False,
-        USER_PROFILE_API_EXTRA_INFO_FIELDS=["arabic_name", "arabic_first_name", "arabic_last_name", "national_id"],
+        USER_PROFILE_API_EXTRA_INFO_FIELDS=[
+            "arabic_name",
+            "arabic_first_name",
+            "arabic_last_name",
+            "national_id",
+            "occupation",
+        ],
         USE_PEARSON_ENGINE_SERVICE=True,
     )
     @patch("eox_nelp.user_profile.api.v1.views.real_time_import_task_v2")
@@ -167,6 +173,7 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
             "arabic_first_name": "أناكين",
             "arabic_last_name": "سكاي ووكر",
             "national_id": "1234512345",
+            "occupation": "student",
         }
         url_endpoint = reverse(self.reverse_viewname)
 

--- a/eox_nelp/user_profile/api/v1/tests/test_views.py
+++ b/eox_nelp/user_profile/api/v1/tests/test_views.py
@@ -147,7 +147,7 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
 
     @override_settings(
         ENABLE_OTP_VALIDATION=False,
-        USER_PROFILE_API_EXTRA_INFO_FIELDS=["arabic_name", "arabic_first_name", "arabic_last_name"],
+        USER_PROFILE_API_EXTRA_INFO_FIELDS=["arabic_name", "arabic_first_name", "arabic_last_name", "national_id"],
         USE_PEARSON_ENGINE_SERVICE=True,
     )
     @patch("eox_nelp.user_profile.api.v1.views.real_time_import_task_v2")
@@ -166,7 +166,7 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
             "arabic_name": "سكاي ووكر أناكين",
             "arabic_first_name": "أناكين",
             "arabic_last_name": "سكاي ووكر",
-            "one_time_password": "correct26",
+            "national_id": "1234512345",
         }
         url_endpoint = reverse(self.reverse_viewname)
 

--- a/eox_nelp/user_profile/api/v1/tests/test_views.py
+++ b/eox_nelp/user_profile/api/v1/tests/test_views.py
@@ -147,7 +147,7 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
 
     @override_settings(
         ENABLE_OTP_VALIDATION=False,
-        USER_PROFILE_API_EXTRA_INFO_FIELDS=["arabic_first_name", "arabic_last_name"],
+        USER_PROFILE_API_EXTRA_INFO_FIELDS=["arabic_name", "arabic_first_name", "arabic_last_name"],
         USE_PEARSON_ENGINE_SERVICE=True,
     )
     @patch("eox_nelp.user_profile.api.v1.views.real_time_import_task_v2")
@@ -163,6 +163,7 @@ class UpdateUserDataTestCase(POSTAuthenticatedTestMixin, APITestCase):
             - Check that user extra info arabic_last_name has been updated.
         """
         payload = {
+            "arabic_name": "سكاي ووكر أناكين",
             "arabic_first_name": "أناكين",
             "arabic_last_name": "سكاي ووكر",
             "one_time_password": "correct26",

--- a/eox_nelp/user_profile/api/v1/views.py
+++ b/eox_nelp/user_profile/api/v1/views.py
@@ -23,7 +23,7 @@ from eox_nelp.edxapp_wrapper.user_api import accounts, errors
 from eox_nelp.one_time_password.view_decorators import validate_otp
 from eox_nelp.pearson_vue_engine.tasks import real_time_import_task_v2
 from eox_nelp.user_profile.required_fields_validation import validate_required_user_fields
-from eox_nelp.utils import save_extrainfo_field
+from eox_nelp.utils import save_extrainfo
 
 logger = logging.getLogger(__name__)
 
@@ -71,10 +71,12 @@ def update_user_data(request):
             # Also some fields related ExtraInfo are not editable too  in the standard implementation. So we need
             # save_extrainfo_field method with the desired settings.
             required_user_extra_info_fields = getattr(settings, 'USER_PROFILE_API_EXTRA_INFO_FIELDS', [])
+            extra_info_data = {
+                field: request.data[field] for field in required_user_extra_info_fields if field in request.data
+            }
 
-            for field in required_user_extra_info_fields:
-                if value := request.data.get(field):
-                    save_extrainfo_field(request.user, field, value)
+            if extra_info_data:
+                save_extrainfo(request.user, extra_info_data)
 
     except errors.AccountValidationError as err:
         return Response({"field_errors": err.field_errors}, status=status.HTTP_400_BAD_REQUEST)

--- a/eox_nelp/utils.py
+++ b/eox_nelp/utils.py
@@ -2,6 +2,9 @@
 import re
 from copy import copy
 
+from custom_reg_form.forms import ExtraInfoForm
+from custom_reg_form.models import ExtraInfo
+from django.core.exceptions import ValidationError
 from opaque_keys.edx.keys import CourseKey
 
 from eox_nelp.edxapp_wrapper.course_overviews import get_course_overviews
@@ -156,21 +159,26 @@ def camel_to_snake(string):
     return re.sub(r'(?<!^)(?=[A-Z])', '_', string).lower()
 
 
-def save_extrainfo_field(user, field, value):
-    """Given a user save in extrainfo a value in the desired field.
+def save_extrainfo(user, data):
+    """Given a user save in extrainfo a value or values in desired fields.
     If the extrainfo doesnt exist, the extrainfo model is created
 
     Args:
         user (User): user instace
-        field (string): extrainfo field to change
-        value (any): value set in extrainfo field
+        data (dict): extra info data in dict format
     """
-    from custom_reg_form.models import ExtraInfo  # pylint: disable=import-outside-toplevel
-    if not hasattr(ExtraInfo, field):
+    validated_data = {field: value for field, value in data.items() if hasattr(ExtraInfo, field)}
+
+    if not validated_data:
         return
 
-    if extra_info := getattr(user, "extrainfo", None):
-        setattr(extra_info, field, value)
-        extra_info.save()
+    extra_info, _ = ExtraInfo.objects.get_or_create(user=user)  # pylint: disable=no-member
+    form_data = extra_info.__dict__
+    form_data.update(validated_data)
+
+    form = ExtraInfoForm(form_data, instance=extra_info)
+
+    if form.is_valid():
+        form.save()
     else:
-        ExtraInfo.objects.create(user=user, **{field: value})  # pylint: disable=no-member
+        raise ValidationError(form.errors)

--- a/eox_nelp/utils.py
+++ b/eox_nelp/utils.py
@@ -4,10 +4,11 @@ from copy import copy
 
 from custom_reg_form.forms import ExtraInfoForm
 from custom_reg_form.models import ExtraInfo
-from django.core.exceptions import ValidationError
+from django.forms.models import model_to_dict
 from opaque_keys.edx.keys import CourseKey
 
 from eox_nelp.edxapp_wrapper.course_overviews import get_course_overviews
+from eox_nelp.edxapp_wrapper.user_api import errors
 
 NATIONAL_ID_REGEX = r"^[1-2]\d{9}$"
 COURSE_ID_REGEX = r'(course-v1:[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
@@ -173,7 +174,7 @@ def save_extrainfo(user, data):
         return
 
     extra_info, _ = ExtraInfo.objects.get_or_create(user=user)  # pylint: disable=no-member
-    form_data = extra_info.__dict__
+    form_data = model_to_dict(extra_info)
     form_data.update(validated_data)
 
     form = ExtraInfoForm(form_data, instance=extra_info)
@@ -181,4 +182,4 @@ def save_extrainfo(user, data):
     if form.is_valid():
         form.save()
     else:
-        raise ValidationError(form.errors)
+        raise errors.AccountValidationError(form.errors)


### PR DESCRIPTION
## Description

Refactored the save_extrainfo function to support updating multiple ExtraInfo fields at once.

Previously, the function only allowed updating a single field per call and directly saved the data without validation.

Now, it uses a ModelForm to ensure that all updates pass validation before saving, improving data integrity and consistency.

## How to test
1. Go to `/eox-nelp/api/user-profile/v1/update-user-data/`
2. Set the setting `USER_PROFILE_API_EXTRA_INFO_FIELDS`
```python
USER_PROFILE_API_EXTRA_INFO_FIELDS = [
    "arabic_first_name",
    "arabic_name",
    "arabic_last_name",
    "national_id",
]
```
3. Make multiple request with valid and invalid data, also the user may or may not have extra info

##### Data examples
```json
{
    "arabic_first_name": "مسؤل",
    "arabic_name": "مسؤل مسؤل",
    "arabic_last_name": "مسؤل",
    "national_id": "12345678",
}

{
    "arabic_first_name": "مسؤل",
    "arabic_name": "invalid",
    "arabic_last_name": "مسؤل",
    "national_id": "12345678",
}

{
    "arabic_first_name": "مسؤل",
    "arabic_name": "invalid",
    "arabic_last_name": "مسؤل",
    "national_id": "invalid",
}
```