### PR TITLE
feat: add support for allow_empty and enhance field validation tests

### DIFF
--- a/eox_nelp/user_profile/required_fields_validation.py
+++ b/eox_nelp/user_profile/required_fields_validation.py
@@ -38,6 +38,8 @@ Additional Field Attributes
     considered invalid.
 - optional_values: Specifies a predefined list of allowed values for a field. Any value outside this list will be
     rejected.
+- allow_empty: Indicates whether an empty value is allowed. If set to `False`, an empty value will be considered
+    invalid.
 
 Field Category Mapping
 
@@ -196,12 +198,7 @@ def validate_user_fields(instance, fields):
             continue
 
         value = getattr(instance, field)
-
-        if not value:
-            errors = ["Empty field"]
-        else:
-            errors = validate_field(value, rules)
-
+        errors = validate_field(value, rules)
         result[field] = errors
 
     return result
@@ -218,6 +215,13 @@ def validate_field(value, rules):
     Returns:
         list: A list of validation error messages. Empty if valid.
     """
+    if not value and not rules.get("allow_empty", False):
+        return ["Empty field"]
+
+    if not value:
+        # This is required since validation supports str fields and None value are not allowed
+        value = ""
+
     errors = []
 
     validators = {

--- a/eox_nelp/user_profile/tests/test_required_fields_validation.py
+++ b/eox_nelp/user_profile/tests/test_required_fields_validation.py
@@ -210,19 +210,6 @@ class ValidateUserFieldsTestCase(TestCase):
 
         self.assertEqual(result, {})
 
-    def test_validate_user_fields_with_empty_value(self):
-        """
-        Test that the function returns the right message when the attribute is empty.
-
-        Expected behavior:
-            - The function should return a dictionary with expected error.
-        """
-        instance = type("UserMock", (), {"username": ""})()
-
-        result = validate_user_fields(instance, {"username": {"max_length": 10}})
-
-        self.assertEqual(result, {"username": ["Empty field"]})
-
     def test_validate_user_fields_with_invalid_field(self):
         """
         Test that the function returns an empty dictionary when an invlaid field has been set.
@@ -325,3 +312,25 @@ class ValidateFieldTestCase(TestCase):
         result = validate_field(value, rules)
 
         self.assertEqual(result, ["max_length with argument 10 failed", "format with argument email failed"])
+
+    def test_validate_field_with_empty_value(self):
+        """
+        Test that the function returns the right message when the attribute is empty.
+
+        Expected behavior:
+            - The function should return the expected error.
+        """
+        result = validate_field("", {"max_length": 10, "allow_empty": False})
+
+        self.assertEqual(result, ["Empty field"])
+
+    def test_validate_field_with_allow_empty(self):
+        """
+        Test that the function returns the expected validation error when the value is None and the allow_empty is True.
+
+        Expected behavior:
+            - The function should return the expected error.
+        """
+        result = validate_field(None, {"max_length": 10, "allow_empty": True, "format": "email"})
+
+        self.assertEqual(result, ["format with argument email failed"])


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR introduces support for the allow_empty attribute in field validation, ensuring that fields explicitly marked with allow_empty: True do not trigger "Empty field" errors. Fields without this attribute or with allow_empty: False will continue to be validated as required.

#### Changes

- Updated validate_field to check for the allow_empty rule before applying other validations.
- Adjusted test cases to cover different scenarios for allow_empty (e.g., empty values with and without the rule).
- Minor refactor in test structure to ensure clarity in validation behaviors.

### Testing instructions
1. Add settings
```
REQUIRED_USER_FIELDS = {
    "account": {
        "first_name": {"max_length": 30, "char_type": "latin"},
        "last_name": {"max_length": 50, "char_type": "latin"},
        "invalid_field": {"max_length": 50, "char_type": "latin"},
    },
    "profile": {
        "country": {"max_length": 2, "optional_values": ["US", "CA", "MX", "CO"]},
        "phone_number": {"max_length": 15, "format": "phone"},
        "mailing_address": {"max_length": 40},
        "invalid_field": {"max_length": 50, "char_type": "latin"},
    },
    "extra_info": {
        "arabic_name": {"max_length": 20, "char_type": "arabic"},
        "arabic_first_name": {"max_length": 20, "char_type": "arabic", "allow_empty": True},
        "arabic_last_name": {"max_length": 50, "char_type": "arabic"},
        "national_id": {"max_length": 50, "format": "numeric"},
    },
}
```
2. Ensure that the current user doesn't have arabic_first_name
3. Go to `eox-nelp/api/user-profile/v1/validated-fields/`
![image](https://github.com/user-attachments/assets/1c2207f1-64b4-4622-a7eb-e818ead8299f)

4. Change allow_empty  to False and verify
![image](https://github.com/user-attachments/assets/172977da-bd5c-4200-b0e4-984bca122a65)

### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
