### PR TITLE
feat: add support for dependent_fields validation

### DIFF
--- a/eox_nelp/user_profile/required_fields_validation.py
+++ b/eox_nelp/user_profile/required_fields_validation.py
@@ -172,7 +172,7 @@ def validate_account_fields(user, account_fields):
     Returns:
         dict: A dictionary with invalid account fields and their errors.
     """
-    return validate_user_fields(user, user, account_fields)
+    return validate_user_fields(user=user, instance=user, fields=account_fields)
 
 
 def validate_profile_fields(user, profile_fields):
@@ -297,8 +297,8 @@ def validate_dependent_field(user, value, arguments):
         "city": {
             "dependent_fields": {
                 "profile.gender": {
-                    "Male": ["Google", "Microsoft", "Amazon"],
-                    "Female": ["Facebook", "Apple", "Netflix"],
+                    "Male": ["Pereira", "Tunja", "Cartagena"],
+                    "Female": ["Manizales", "Barranquilla", "Armenia"],
                 },
                 "profile.country": {
                     "CO": ["Bogota", "Medellin", "Cali"],

--- a/eox_nelp/user_profile/tests/test_required_fields_validation.py
+++ b/eox_nelp/user_profile/tests/test_required_fields_validation.py
@@ -95,7 +95,11 @@ class ValidateAccountFieldsTestCase(TestCase):
         mock_validate_user_fields.return_value = {"username": ["max_length exceeded"]}
         result = validate_account_fields(user, {"username": {"max_length": 10}})
 
-        mock_validate_user_fields.assert_called_once_with(user, user, {"username": {"max_length": 10}})
+        mock_validate_user_fields.assert_called_once_with(
+            user=user,
+            instance=user,
+            fields={"username": {"max_length": 10}},
+        )
         self.assertEqual(result, {"username": ["max_length exceeded"]})
 
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR introduces support for the dependent_fields validation rule in the user field validation logic. This enhancement allows a field's valid values to be conditional on another field’s value.


#### Changes
- Implemented validate_dependent_field to check if a field's value adheres to constraints based on the values of other related fields.
- Updated validate_user_fields to incorporate validate_dependent_field.
- Extended the REQUIRED_USER_FIELDS structure to support dependent_fields, enabling rules where one field's valid values depend on another.


## Testing instructions
1. Add settings e.g
``` python
REQUIRED_USER_FIELDS = {
    "account": {
        "first_name": {"max_length": 30, "char_type": "latin"},
        "last_name": {"max_length": 50, "char_type": "latin"},
        "invalid_field": {"max_length": 50, "char_type": "latin"},
    },
    "profile": {
        "city": {
            "max_length": 32,
            "char_type": "latin",
            "dependent_fields": {
                "gender": { # Invalid field
                    "Male": ["Cali", "Medellin"],
                    "Female": ["Bogota", "Cota", "Chia"]
                },
                "profile.country": {
                    "CO": ["Bogota", "Medellin", "Cali"],
                    "US": "Florida"
                }
            }
        },
        "country": {"max_length": 2, "optional_values": ["US", "CA", "MX", "CO"]},
        "phone_number": {"max_length": 15, "format": "phone"},
        "mailing_address": {"max_length": 40},
        "invalid_field": {"max_length": 50, "char_type": "latin"},
    },
    "extra_info": {
        "arabic_name": {"max_length": 20, "char_type": "arabic"},
        "arabic_first_name": {"max_length": 20, "char_type": "arabic", "allow_empty": True},
        "arabic_last_name": {"max_length": 50, "char_type": "arabic"},
        "national_id": {"max_length": 50, "format": "numeric"},
        "occupation": {"max_length": 50, "char_type": "latin"},
        "sector": {
            "max_length": 50,
            "char_type": "latin",
            "allow_empty": True,
            "dependent_fields": {
                "extrainfo.occupation": {
                    "employee": ["public", "private", "non_profit"]
                },
            },
        },
    },
}
```
2. go to `eox-nelp/api/user-profile/v1/validated-fields/`
3. Check result with example setting if the occupation is employee the sector value must be on of them ["public", "private", "non_profit"] or if country is US the city must be Florida
![image](https://github.com/user-attachments/assets/98f62627-1fa0-4e22-aa06-693d262feeee)

### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
