### PR TITLE
feat: add get_conditional_user_fields API

### DIFF
--- a/eox_nelp/user_profile/api/v1/urls.py
+++ b/eox_nelp/user_profile/api/v1/urls.py
@@ -1,11 +1,12 @@
 """eox_nelp user_profile.api v1 urls"""
 from django.urls import path
 
-from eox_nelp.user_profile.api.v1.views import get_validated_user_fields, update_user_data
+from eox_nelp.user_profile.api.v1.views import get_conditional_user_fields, get_validated_user_fields, update_user_data
 
 app_name = "eox_nelp"  # pylint: disable=invalid-name
 
 urlpatterns = [
     path("update-user-data/", update_user_data, name="update-user-data"),
     path("validated-fields/", get_validated_user_fields, name="validated-fields"),
+    path("conditional-fields/", get_conditional_user_fields, name="conditional-fields"),
 ]

--- a/eox_nelp/user_profile/api/v1/views.py
+++ b/eox_nelp/user_profile/api/v1/views.py
@@ -133,3 +133,63 @@ def get_validated_user_fields(request):
     validated_fields = validate_required_user_fields(request.user)
 
     return Response(validated_fields, status=status.HTTP_200_OK)
+
+
+@api_view(["GET"])
+@authentication_classes((SessionAuthenticationAllowInactiveUser,))
+@permission_classes((IsAuthenticated,))
+def get_conditional_user_fields(request):  # pylint: disable=unused-argument
+    """
+    Retrieves the conditional user field configuration.
+
+    This API endpoint returns the `CONDITIONAL_USER_FIELDS` setting, which defines
+    the dynamic field dependencies for user input forms. The structure outlines how
+    certain fields depend on the values of other fields, helping front-end applications
+    dynamically adjust form fields based on user selections.
+
+    ## Usage
+
+    ### **GET** /eox-nelp/api/user-profile/v1/conditional-fields/
+
+    Example Response:
+    ```json
+    {
+        "occupation": {
+            "type": "choices",
+            "options": ["employee", "student", "unemployed"],
+            "dependent_fields": {
+                "employee": {
+                    "sector": {
+                        "type": "choices",
+                        "options": ["public", "private", "non_profit"],
+                        "dependent_fields": {
+                            "public": {
+                                "type": "choices",
+                                "options": ["Government", "Education", "Healthcare"]
+                            },
+                            "private": {
+                                "type": "text",
+                                "placeholder": "Enter specific private sector"
+                            },
+                            "non_profit": {
+                                "type": "text",
+                                "placeholder": "Enter specific non-profit sector"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ```
+
+    Authentication:
+        - Requires an authenticated user session.
+
+    Returns:
+        JsonResponse: A JSON object containing the `CONDITIONAL_USER_FIELDS` settings.
+
+    HTTP Status Codes:
+        - 200 OK: The request was successful, and the conditional field data is returned.
+    """
+    return Response(getattr(settings, "CONDITIONAL_USER_FIELDS", {}), status=status.HTTP_200_OK)


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR introduces a new API endpoint that returns conditional user fields based on the Django settings configuration. This endpoint provides dynamic field validation rules for frontend forms.

### Changes Introduced

**New API View (get_conditional_user_fields):**

- Fetches CONDITIONAL_USER_FIELDS from Django settings.
- Returns the configuration as a JSON response.
- Ensures proper authentication and permissions.

**Unit Tests:**

- Validates that the API correctly retrieves the expected settings.
- Ensures an empty response when CONDITIONAL_USER_FIELDS is not set.

**Consistent API Integration:**

- Structured similarly to existing profile-related endpoints.
- Improves maintainability and flexibility for conditional field validation.

## Testing instructions
1. Set setting `CONDITIONAL_USER_FIELDS`. e.g
```
    {
        "occupation": {
            "type": "choices",
            "options": ["employee", "student", "unemployed"],
            "dependent_fields": {
                "employee": {
                    "sector": {
                        "type": "choices",
                        "options": ["public", "private", "non_profit"],
                        "dependent_fields": {
                            "public": {
                                "type": "choices",
                                "options": ["Government", "Education", "Healthcare"]
                            },
                            "private": {
                                "type": "text",
                                "placeholder": "Enter specific private sector"
                            },
                            "non_profit": {
                                "type": "text",
                                "placeholder": "Enter specific non-profit sector"
                            }
                        }
                    }
                }
            }
        }
    }
```
2. Run the Django development server and access: `/eox-nelp/api/user-profile/v1/conditional-fields/`
3. Confirm the response matches the configured  `CONDITIONAL_USER_FIELDS`.

### Before

### After

## Additional information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
