### PR TITLE
feat: create retire user admin action

### DIFF
--- a/eox_nelp/admin/user.py
+++ b/eox_nelp/admin/user.py
@@ -5,14 +5,16 @@ Classes:
     NelpUserAdmin: Custom admin class for User model to include extra info fields like national_id.
     UserExtraInfoInline: inline for extra info model
 """
-
-
 from custom_reg_form.models import ExtraInfo
+from django.contrib import admin, messages
 from django.contrib.admin import StackedInline
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 from eox_support.admin.user import SupportUserAdmin  # pylint: disable=import-error
 
 from eox_nelp.admin.register_admin_model import register_admin_model as register
+from eox_nelp.edxapp_wrapper.django_comment_common import comment_client
+from eox_nelp.edxapp_wrapper.user_api import accounts, models
 
 User = get_user_model()
 
@@ -29,6 +31,7 @@ class NelpUserAdmin(SupportUserAdmin):
     list_display = SupportUserAdmin.list_display[:2] + ('user_national_id',) + SupportUserAdmin.list_display[2:]
     search_fields = SupportUserAdmin.search_fields + ('extrainfo__national_id',)
     inlines = SupportUserAdmin.inlines + (UserExtraInfoInline,)
+    actions = ['retire_users']
 
     def user_national_id(self, instance):
         """Return national_id associated with the user extra_info instance."""
@@ -36,6 +39,47 @@ class NelpUserAdmin(SupportUserAdmin):
             return instance.extrainfo.national_id
 
         return None
+
+    @admin.action(description="Retire selected users")
+    def retire_users(self, request, queryset):
+        """
+        Admin action to retire selected users from the Django admin interface.
+
+        This action performs the following steps for each selected user:
+        - Appends a unique timestamp-based label to the user's email and username to mark retirement.
+        - Saves the updated user object to persist the new identifiers.
+        - Creates a retirement request and deactivates the user account.
+        - Deletes any associated ExtraInfo records.
+        - Attempts to retire the user from the external comment/forum service.
+
+        If the user has already been retired, a RetirementStateError is caught and an error message is shown.
+        If the user does not exist in the comment service, a 404 is caught and a message is shown.
+        Any other unexpected exceptions are logged as errors in the admin interface.
+
+        Args:
+            request: The HttpRequest object.
+            queryset: A QuerySet of selected User instances to retire.
+        """
+        timestamp = int(timezone.now().timestamp())
+        label = f"-retired-by-{request.user.username}-{timestamp}"
+
+        for user in queryset:
+            try:
+                cc_user = comment_client.User.from_django_user(user)
+                user.email += label
+                user.username += label
+                user.save()
+                accounts.utils.create_retirement_request_and_deactivate_account(user)
+                ExtraInfo.objects.filter(user=user).delete()  # pylint: disable=no-member
+                cc_user.retire(user.username)
+            except models.RetirementStateError:
+                messages.error(request, f"User retirement already exist for user with id {user.id}")
+            except comment_client.CommentClientRequestError as exc:
+                if exc.status_code != 404:
+                    raise
+                messages.error(request, f"User with id {user.id} not found in forum service")
+            except Exception as exc:  # pylint: disable=broad-except
+                messages.error(request, f"Error during soft delete process for user ID {user.id}: {str(exc)}")
 
 
 register(User, NelpUserAdmin)

--- a/eox_nelp/edxapp_wrapper/backends/django_comment_common_r_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/django_comment_common_r_v1.py
@@ -1,0 +1,16 @@
+"""Backend for django_comment_common app.
+
+This file contains all the necessary dependencies from
+https://github.com/nelc/edx-platform/tree/open-release/redwood.nelp/openedx/core/djangoapps/django_comment_common
+"""
+from openedx.core.djangoapps.django_comment_common import comment_client  # pylint: disable=import-error
+
+
+def get_comment_client():
+    """Allow to get the package comment_client from
+    https://github.com/nelc/edx-platform/tree/open-release/redwood.nelp/openedx/core/djangoapps/django_comment_common/comment_client
+
+    Returns:
+        comment_client package.
+    """
+    return comment_client

--- a/eox_nelp/edxapp_wrapper/backends/user_api_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/backends/user_api_m_v1.py
@@ -3,7 +3,7 @@
 This file contains all the necessary dependencies from
 https://github.com/eduNEXT/edunext-platform/tree/master/openedx/core/djangoapps/user_api
 """
-from openedx.core.djangoapps.user_api import accounts, errors  # pylint: disable=import-error
+from openedx.core.djangoapps.user_api import accounts, errors, models  # pylint: disable=import-error
 
 
 def get_accounts():
@@ -24,3 +24,13 @@ def get_errors():
         errors module.
     """
     return errors
+
+
+def get_models():
+    """Allow to get the module models from
+    https://github.com/nelc/edx-platform/blob/open-release/redwood.nelp/openedx/core/djangoapps/user_api/models.py
+
+    Returns:
+        models module.
+    """
+    return models

--- a/eox_nelp/edxapp_wrapper/django_comment_common.py
+++ b/eox_nelp/edxapp_wrapper/django_comment_common.py
@@ -1,0 +1,16 @@
+"""
+Wrapper django_comment_common app.
+
+This contains all the required dependencies from django_comment_common
+
+Attributes:
+    backend: Imported django_comment_common module by using the plugin settings.
+    comment_client: Wrapper comment_client package.
+"""
+from importlib import import_module
+
+from django.conf import settings
+
+backend = import_module(settings.EOX_NELP_DJANGO_COMMENT_COMMON_BACKEND)
+
+comment_client = backend.get_comment_client()

--- a/eox_nelp/edxapp_wrapper/test_backends/django_comment_common_r_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/django_comment_common_r_v1.py
@@ -1,0 +1,11 @@
+"""Backend test abstraction."""
+from mock import Mock
+
+
+def get_comment_client():
+    """Return test package.
+
+    Returns:
+        Mock instance.
+    """
+    return Mock()

--- a/eox_nelp/edxapp_wrapper/test_backends/user_api_m_v1.py
+++ b/eox_nelp/edxapp_wrapper/test_backends/user_api_m_v1.py
@@ -30,3 +30,12 @@ def get_errors():
         "AccountValidationError": AccountValidationError,
         "AccountUpdateError": AccountUpdateError,
     })
+
+
+def get_models():
+    """Return test module.
+
+    Returns:
+        Mock instance.
+    """
+    return Mock()

--- a/eox_nelp/edxapp_wrapper/user_api.py
+++ b/eox_nelp/edxapp_wrapper/user_api.py
@@ -4,8 +4,9 @@ Wrapper user_api app.
 This contains all the required dependencies from user_api
 
 Attributes:
-    backend:Imported user_api module by using the plugin settings.
+    backend: Imported user_api module by using the plugin settings.
     accounts: Wrapper accounts module.
+    models: Wrapper models module.
 
 """
 from importlib import import_module
@@ -16,3 +17,4 @@ backend = import_module(settings.EOX_NELP_USER_API)
 
 accounts = backend.get_accounts()
 errors = backend.get_errors()
+models = backend.get_models()

--- a/eox_nelp/settings/common.py
+++ b/eox_nelp/settings/common.py
@@ -56,6 +56,7 @@ def plugin_settings(settings):
     settings.EOX_NELP_INSTRUCTOR_BACKEND = 'eox_nelp.edxapp_wrapper.backends.instructor_m_v1'
     settings.EOX_NELP_COURSE_EXPERIENCE_BACKEND = 'eox_nelp.edxapp_wrapper.backends.course_experience_p_v1'
     settings.EOX_NELP_THIRD_PARTY_AUTH_BACKEND = 'eox_nelp.edxapp_wrapper.backends.third_party_auth_r_v1'
+    settings.EOX_NELP_DJANGO_COMMENT_COMMON_BACKEND = 'eox_nelp.edxapp_wrapper.backends.django_comment_common_r_v1'
 
     settings.FUTUREX_API_URL = 'https://testing-site.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -40,6 +40,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.EOX_NELP_INSTRUCTOR_BACKEND = "eox_nelp.edxapp_wrapper.test_backends.instructor_m_v1"
     settings.EOX_NELP_COURSE_EXPERIENCE_BACKEND = "eox_nelp.edxapp_wrapper.test_backends.course_experience_p_v1"
     settings.EOX_NELP_THIRD_PARTY_AUTH_BACKEND = "eox_nelp.edxapp_wrapper.test_backends.third_party_auth_r_v1"
+    settings.EOX_NELP_DJANGO_COMMENT_COMMON_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.django_comment_common_r_v1'
 
     settings.FUTUREX_API_URL = 'https://testing.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'


### PR DESCRIPTION
## Description

This pull request introduces a new Django admin action named retire_users to the NelpUserAdmin class. This feature enables administrators to retire selected users directly from the Django admin interface

#### Key Changes:
###### New Admin Action: retire_users

- Appends a timestamped suffix to the user's email and username to mark the retirement.=
- Deactivates the user account and creates a retirement request using the user API.
- Deletes any associated ExtraInfo records from custom_reg_form.models.
- Calls the forum service (via comment_client) to retire the user from the comment system.

###### Error Handling:

- Catches RetirementStateError if a user is already retired and logs it via admin messages.
- Gracefully handles 404 errors from the forum service when the user record is missing.
- Catches and reports any unexpected exceptions during the process.

###### Admin Enhancements:

- Updated actions list to include retire_users.
- Added user_national_id method to show national ID inline in the user list display.

## Testing instructions

This guide explains how to verify the functionality of the "Retire selected users" action in the Django admin.

### Steps

1. Go to the Django admin panel (`/admin/auth/user/`) and log in as a superuser or a staff user with permission.

2. Select the user(s) you want to retire by checking the boxes next to their names.

3. From the actions dropdown, select **"Retire selected users"** and click **"Go"**.

4. After executing the action:
   - The user's `username` will be modified by appending a suffix:
     ```
     -retired-by-<admin_username>-<timestamp>
     ```
     Example:
     ```
     john.doe-retired-by-admin-1715799426
     ```
   - You should be able to create a **new user** with the original username and email (before the suffix).

5. Go to `/admin/user_api/userretirementstatus/` and confirm that a new record has been created:
   - The `status` should be `pending`.
   - The record should be linked to the retired user.

6. To confirm the user was also retired from the forum service:
   - Connect to the MongoDB container:

     ```bash
     docker exec -it tutor_dev-mongodb-1 bash
     mongosh
     use cs_comments_service
     db.users.find({"username": "retired-username"}).pretty()
     ```

   - Replace `"retired-username"` with the actual updated username.




