### PR TITLE
feat: add Cloud CDN signed cookie middleware and unit tests

### DIFF
--- a/eox_nelp/middleware.py
+++ b/eox_nelp/middleware.py
@@ -1,4 +1,109 @@
 """Middleware file.
 
-Required NELP middlewares that allow to customize edx-platform.
+Required NELP middlewares that allow customizing edx-platform.
 """
+
+import base64
+import hashlib
+import hmac
+import time
+
+from django.conf import settings
+
+
+class GCPCloudCDNSignedCookieMiddleware:
+    """
+    Middleware that generates and attaches a Google Cloud CDN signed cookie.
+
+    The cookie is only generated for authenticated users and is signed using
+    the key configured for the Cloud CDN backend bucket.
+    """
+
+    COOKIE_NAME = "Cloud-CDN-Cookie"
+
+    def __init__(self, get_response):
+        """
+        Initialize middleware with Django's response handler.
+        """
+        self.get_response = get_response
+
+    def _sign(self, data: bytes) -> str:
+        """
+        Generate the HMAC-SHA1 signature required by Google Cloud CDN.
+
+        - Decodes the base64url key from settings.
+        - Signs the payload using HMAC-SHA1.
+        - Returns a base64url-encoded signature without padding.
+
+        Args:
+            data (bytes): The payload to sign.
+
+        Returns:
+            str: Base64url-encoded signature.
+        """
+        key = base64.urlsafe_b64decode(
+            settings.GCP_CLOUD_CDN_SIGNING_KEY + "===="
+        )
+        signature = hmac.new(key, data, hashlib.sha1).digest()
+
+        return base64.urlsafe_b64encode(signature).decode().rstrip("=")
+
+    def _build_signed_cookie_value(self) -> str:
+        """
+        Build the full Google Cloud CDN signed cookie value.
+
+        Includes:
+        - URLPrefix (base64url)
+        - Expires (UNIX timestamp)
+        - KeyName
+        - Signature
+
+        Required format:
+        URLPrefix=...:Expires=...:KeyName=...:Signature=...
+
+        Returns:
+            str: Final cookie value.
+        """
+        expires = int(time.time()) + settings.GCP_CLOUD_CDN_COOKIE_MAX_AGE
+
+        encoded_prefix = base64.urlsafe_b64encode(
+            settings.GCP_CLOUD_CDN_URL_PREFIX.encode()
+        ).decode().rstrip("=")
+
+        policy = (
+            f"URLPrefix={encoded_prefix}:"
+            f"Expires={expires}:"
+            f"KeyName={settings.GCP_CLOUD_CDN_SIGNING_KEY_NAME}"
+        )
+
+        signature = self._sign(policy.encode())
+
+        return f"{policy}:Signature={signature}"
+
+    def __call__(self, request):
+        """
+        Process each request and attach the signed cookie to the response
+        if the user is authenticated.
+
+        The cookie is manually constructed to avoid Django adding quotes,
+        which would break Cloud CDN validation.
+        """
+        response = self.get_response(request)
+
+        if (user := getattr(request, "user", None)) and user.is_authenticated:
+            cookie_value = self._build_signed_cookie_value()
+
+            parts = [
+                f"{self.COOKIE_NAME}={cookie_value}",
+                f"Max-Age={settings.GCP_CLOUD_CDN_COOKIE_MAX_AGE}",
+                "Path=/",
+            ]
+
+            if cookie_domain := getattr(
+                settings, "GCP_CLOUD_CDN_COOKIE_DOMAIN", None
+            ):
+                parts.append(f"Domain={cookie_domain}")
+
+            response["Set-Cookie"] = "; ".join(parts)
+
+        return response

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -14,7 +14,7 @@ class SettingsClass:
     """ dummy settings class """
 
 
-def test_plugin_settings(settings):
+def test_plugin_settings(settings):  # pylint: disable=too-many-statements
     """
     Defines eox-nelp settings when app is used as a plugin to edx-platform.
     See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
@@ -70,6 +70,11 @@ def test_plugin_settings(settings):
     settings.PEARSON_ENGINE_API_URL = 'https://testing.com'
     settings.PEARSON_ENGINE_API_CLIENT_SECRET = "12345678p"
     settings.PEARSON_ENGINE_API_CLIENT_ID = "12345678"
+
+    settings.GCP_CLOUD_CDN_SIGNING_KEY_NAME = "test-key"
+    settings.GCP_CLOUD_CDN_SIGNING_KEY = "MDEyMzQ1Njc4OWFiY2RlZg"
+    settings.GCP_CLOUD_CDN_URL_PREFIX = "http://test/"
+    settings.GCP_CLOUD_CDN_COOKIE_MAX_AGE = 3600
 
 
 PLATFORM_NAME = "Testing environment"

--- a/eox_nelp/tests/test_middleware.py
+++ b/eox_nelp/tests/test_middleware.py
@@ -1,0 +1,122 @@
+"""
+Test middlewares file.
+"""
+
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from django.test import override_settings
+
+from eox_nelp.middleware import GCPCloudCDNSignedCookieMiddleware
+
+
+class GCPCloudCDNSignedCookieMiddlewareTestCase(TestCase):
+    """
+    Unit tests for GCPCloudCDNSignedCookieMiddleware.
+    """
+
+    def setUp(self):
+        """Setup common conditions for every test case."""
+        self.middleware = GCPCloudCDNSignedCookieMiddleware(
+            get_response=Mock()
+        )
+
+    @patch("eox_nelp.middleware.time.time", return_value=1700000000)
+    def test_build_signed_cookie_value(self, _time_mock):
+        """
+        This method tests the desired behavior of _build_signed_cookie_value.
+        Expected behavior:
+            - Return a string value.
+            - Return a value containing URLPrefix.
+            - Return a value containing Expires with expected timestamp.
+            - Return a value containing KeyName.
+            - Return a value containing Signature.
+        """
+        result = self.middleware._build_signed_cookie_value()  # pylint: disable=protected-access
+
+        self.assertIsInstance(result, str)
+        self.assertIn("URLPrefix=", result)
+        self.assertIn("Expires=1700003600", result)
+        self.assertIn("KeyName=test-key", result)
+        self.assertIn("Signature=", result)
+
+    def test_sign_returns_valid_string(self):
+        """
+        This method tests the desired behavior of _sign.
+        Expected behavior:
+            - Return a string.
+            - Return a non-empty value.
+            - Return a value without '=' padding.
+        """
+        result = self.middleware._sign(b"test-data")  # pylint: disable=protected-access
+
+        self.assertIsInstance(result, str)
+        self.assertTrue(result)
+        self.assertNotIn("=", result)
+
+    @patch.object(
+        GCPCloudCDNSignedCookieMiddleware,
+        "_build_signed_cookie_value",
+        return_value="signed-cookie-value",
+    )
+    def test_call_sets_cookie_for_authenticated_user(self, _mock_cookie):
+        """
+        This method tests the desired behavior of __call__ when the user
+        is authenticated.
+        Expected behavior:
+            - get_response called once.
+            - Response contains Set-Cookie header.
+            - Set-Cookie contains cookie name.
+        """
+        request = Mock()
+        request.user = Mock(is_authenticated=True)
+
+        response = {}
+        self.middleware.get_response = Mock(return_value=response)
+
+        result = self.middleware(request)
+
+        self.middleware.get_response.assert_called_once_with(request)
+        self.assertIn("Set-Cookie", result)
+        self.assertIn("Cloud-CDN-Cookie=", result["Set-Cookie"])
+
+    def test_call_does_not_set_cookie_for_unauthenticated_user(self):
+        """
+        This method tests the desired behavior of __call__ when the user
+        is not authenticated.
+        Expected behavior:
+            - get_response called once.
+            - Response does not contain Set-Cookie header.
+        """
+        request = Mock()
+        request.user = Mock(is_authenticated=False)
+
+        response = {}
+        self.middleware.get_response = Mock(return_value=response)
+
+        result = self.middleware(request)
+
+        self.middleware.get_response.assert_called_once_with(request)
+        self.assertNotIn("Set-Cookie", result)
+
+    @override_settings(GCP_CLOUD_CDN_COOKIE_DOMAIN="local.openedx.io")
+    def test_call_sets_cookie_domain_when_cookie_domain_setting_exists(self):
+        """
+        This method tests the desired behavior of __call__ when the cookie
+        domain setting exists.
+        Expected behavior:
+            - get_response called once.
+            - Response contains Set-Cookie header.
+            - Set-Cookie contains Domain with the configured value.
+        """
+        request = Mock()
+        request.user = Mock(is_authenticated=True)
+
+        response = {}
+        self.middleware.get_response = Mock(return_value=response)
+
+        result = self.middleware(request)
+
+        self.middleware.get_response.assert_called_once_with(request)
+        self.assertIn("Set-Cookie", result)
+        self.assertIn("Domain=local.openedx.io", result["Set-Cookie"])


### PR DESCRIPTION
## Summary

This PR introduces a middleware to generate and attach Google Cloud CDN signed cookies, enabling secure access to private assets stored in GCS.

## Changes

- Added `GCPCloudCDNSignedCookieMiddleware`
  - Generates signed cookies for authenticated users
  - Uses Cloud CDN signing key configured in the backend bucket
  - Manually sets the `Set-Cookie` header to avoid quoting issues
- Added generic settings:
  - `GCP_CLOUD_CDN_SIGNING_KEY_NAME`
  - `GCP_CLOUD_CDN_SIGNING_KEY`
  - `GCP_CLOUD_CDN_URL_PREFIX`
  - `GCP_CLOUD_CDN_COOKIE_MAX_AGE`
  - `GCP_CLOUD_CDN_COOKIE_DOMAIN`
- Added unit tests covering:
  - Cookie generation
  - Signature generation
  - Authenticated vs unauthenticated behavior
  - Cookie domain handling

## Motivation

Cloud CDN requires signed cookies (or signed URLs) to serve content from private GCS buckets.

Since Open edX generates asset URLs with query parameters (e.g. `?v=...`), signed URLs are not viable.  
This implementation enables access using signed cookies without modifying existing URL generation logic.

## Testing

- Unit tests implemented and passing
- Manual validation performed using browser and `curl`
- Verified:
  - Cookie format is valid for Cloud CDN
  - Cookie must not include quotes
  - Cookie name must be `Cloud-CDN-Cookie`
  - Access works correctly when cookie is present

## Notes

- Requires a configured Cloud CDN backend bucket with a signed URL key
- Signing key must match Terraform configuration
- Middleware applies globally and can be reused for any CDN-protected assets