### PR TITLE
feat: Add Database Router for Read Replica Support

### DIFF
--- a/eox_nelp/db.py
+++ b/eox_nelp/db.py
@@ -1,0 +1,22 @@
+"""Database router to route read queries to a read replica database."""
+
+from django.conf import settings
+
+
+class AppLabelReadReplicaRouter:
+    """
+    A database router that directs read operations for specified apps to a read replica database.
+    The apps to route can be configured via the 'READ_REPLICA_APPS_LABELS_FORCED' setting.
+    https://docs.djangoproject.com/en/5.0/topics/db/multi-db/#using-routers
+    """
+
+    route_app_labels = getattr(settings, "READ_REPLICA_APPS_LABELS_FORCED", [])
+
+    def db_for_read(self, model, **hints):  # pylint: disable=unused-argument
+        """
+        Only handles reading. If the app matches, use the replica.
+        """
+        # pylint: disable=protected-access
+        if model._meta.app_label in self.route_app_labels and "read_replica" in settings.DATABASES:
+            return "read_replica"
+        return None


### PR DESCRIPTION
## PR Description: Add Database Router for Read Replica Support

### Overview

This pull request introduces a new database router, `AppLabelReadReplicaRouter`, to the codebase. The router enables routing of read operations for specific Django apps to a designated read replica database. This is particularly useful for scaling read-heavy workloads and improving application performance by offloading read queries from the primary database.

### Details

- **Router Class:** `AppLabelReadReplicaRouter`
- **Configuration:** The list of app labels to be routed is configurable via the Django setting `READ_REPLICA_APPS_LABELS_FORCED`.
- **Routing Logic:** 
  - If a model's app label is in the configured list and a `read_replica` database is defined in `settings.DATABASES`, read operations for that model will be routed to the `read_replica` database.
  - All other operations or models not in the list will use the default database routing.

### Usage

1. **Configure App Labels:**
   - Add a list of app labels to your Django settings:
     ```python
     READ_REPLICA_APPS_LABELS_FORCED = ["my_app", "another_app"]
     ```
2. **Define Read Replica:**
   - Ensure `read_replica` is defined in your `DATABASES` setting.

3. **Enable Router:**
   - Add the router to your `DATABASE_ROUTERS` setting:
     ```python
     DATABASE_ROUTERS = ["path.to.AppLabelReadReplicaRouter"]
     ```

### Reference

- [Django Multi-DB Routers Documentation](https://docs.djangoproject.com/en/5.0/topics/db/multi-db/#using-routers)

---

This change is backward-compatible and does not affect write operations or apps not listed in the configuration.