### PR TITLE
feat: implementation of national id as xapi actor identifier using ac…

### DIFF
--- a/eox_nelp/openedx_filters/tests/xapi/test_filters.py
+++ b/eox_nelp/openedx_filters/tests/xapi/test_filters.py
@@ -10,7 +10,9 @@ Classes:
 """
 import json
 
+from custom_reg_form.models import ExtraInfo
 from ddt import data, ddt, unpack
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from mock import Mock, patch
@@ -43,13 +45,13 @@ class XApiActorFilterTestCase(TestCase):
         )
         self.username = "xapi"
         self.email = "xapi@example.com"
-        User.objects.update_or_create(username=self.username, email=self.email)
+        self.user, _ = User.objects.update_or_create(username=self.username, email=self.email)
 
     def test_user_does_not_exist(self):
         """ Test case when the user is not found by the email.
 
         Expected behavior:
-            - Returned value is the same as the given value.
+            - Returned value is the same as the given value (original Agent with mbox).
         """
         email = "invalid-email@example.com"
         actor = Agent(
@@ -73,12 +75,15 @@ class XApiActorFilterTestCase(TestCase):
 
         self.assertRaises(TypeError, self.filter.run_filter, actor)
 
-    def test_update_given_actor(self):
-        """ Test case when the result is updated with the username.
+    @override_settings(LMS_ROOT_URL="https://lms.example.com")
+    def test_update_given_actor_with_username_fallback(self):
+        """ Test case when the user exists but has no national_id.
 
         Expected behavior:
-            - Returned value contains right mbox value.
-            - Returned value contains right name value.
+            - Returned value contains the right name value.
+            - Returned value contains the right account homePage value.
+            - Returned value contains the username as the account name (fallback).
+            - Returned value does not contain the mbox attribute.
         """
         actor = Agent(
             mbox=self.email,
@@ -86,8 +91,37 @@ class XApiActorFilterTestCase(TestCase):
 
         actor = self.filter.run_filter(transformer=Mock(), result=actor)["result"]
 
-        self.assertEqual(f"mailto:{self.email}", actor.mbox)
         self.assertEqual(self.username, actor.name)
+        self.assertEqual(settings.LMS_ROOT_URL, actor.account.home_page)
+        self.assertEqual(self.username, actor.account.name)
+        self.assertIsNone(getattr(actor, 'mbox', None))
+
+    @override_settings(LMS_ROOT_URL="https://lms.example.com")
+    def test_update_given_actor_with_national_id(self):
+        """ Test case when the user exists and has a national_id in extrainfo.
+
+        Expected behavior:
+            - Returned value contains the right name value.
+            - Returned value contains the national_id as the account name.
+            - Returned value contains the right account homePage value.
+        """
+        national_id = "123456789"
+        ExtraInfo.objects.get_or_create(  # pylint: disable=no-member
+            user=self.user,
+            arabic_name="مسؤل",
+            national_id=national_id,
+            occupation="student",
+        )
+
+        actor = Agent(
+            mbox=self.email,
+        )
+
+        actor = self.filter.run_filter(transformer=Mock(), result=actor)["result"]
+
+        self.assertEqual(self.username, actor.name)
+        self.assertEqual(national_id, actor.account.name)
+        self.assertEqual(settings.LMS_ROOT_URL, actor.account.home_page)
 
 
 class XApiCourseObjectFilterTestCase(TestCase):

--- a/eox_nelp/openedx_filters/xapi/filters.py
+++ b/eox_nelp/openedx_filters/xapi/filters.py
@@ -23,42 +23,49 @@ User = get_user_model()
 
 
 class XApiActorFilter(PipelineStep):
-    """This filter modifies the given actor by adding the username.
+    """
+    This filter modifies the xAPI actor to use 'account' as the Inverse Functional Identifier (IFI).
 
-    Setting XAPI_AGENT_IFI_TYPE = "mbox" is required in order to get the compatible actor, for
-    details please check the event-routing-backends library.
-    https://github.com/openedx/event-routing-backends/blob/master/event_routing_backends/processors/xapi/transformer.py#L89
+    It prioritizes the National ID from the user's extra information. If the National ID
+    is not available, it falls back to the username. The 'name' field remains the username
+    for display purposes.
 
-    How to set:
-        OPEN_EDX_FILTERS_CONFIG = {
-            "event_routing_backends.processors.xapi.transformer.xapi_transformer.get_actor": {
-                "pipeline": ["eox_nelp.openedx_filters.xapi.filters.XApiActorFilter"],
-                "fail_silently": False,
-            }
-        }
+    The 'account' object requires:
+        - homePage: The base URL of the system.
+        - name: The unique identifier (National ID or Username).
     """
 
     def run_filter(self, transformer, result):  # pylint: disable=arguments-differ, unused-argument
-        """Extracts the email for the given result in order to get the user and returns
-        new Agent with email a name.
+        """
+        Updates the actor agent to use an account identifier based on National ID or Username.
 
         Arguments:
             transformer <XApiTransformer>: Transformer instance.
-            result <Agent>: default Actor agent of event-routing-backends
+            result <Agent>: Default Actor agent from event-routing-backends.
 
         Returns:
-            Agent: New agent with name and email if user exist otherwise given agent.
+            dict: Dictionary containing the updated Agent with account credentials.
         """
         mbox = result.mbox
         email = mbox.replace("mailto:", "") if "mailto:" in mbox else mbox
 
         try:
+            # Retrieve the user by email to access profile/extra information
             user = User.objects.get(email=email)
+            extrainfo = getattr(user, 'extrainfo', None)
+            national_id = getattr(extrainfo, 'national_id', None) if extrainfo else None
+            identifier = str(national_id) if national_id else user.username
+
             result = Agent(
-                mbox=user.email,
                 name=user.username,
+                account={
+                    "homePage": settings.LMS_ROOT_URL,  # System's home page
+                    "name": identifier
+                },
+                objectType="Agent"
             )
         except User.DoesNotExist:
+            # If user is not found, we keep the default result provided by the pipeline
             pass
 
         return {


### PR DESCRIPTION
## Description
This PR refactors the `XApiActorFilter` to comply with the new requirement of using the **National ID** as the primary actor identifier. 

Since the xAPI standard's `mbox` field only accepts `mailto:` URI schemes, we have transitioned the actor's Inverse Functional Identifier (IFI) from `mbox` to the `account` object.

## Changes
* **Actor Identification Logic**: Updated the filter to prioritize `user.extrainfo.national_id`.
* **Fallback Mechanism**: If the National ID is not available, the system falls back to the `user.username`.
* **xAPI Compliance**: Replaced `mbox` with the `account` object containing `homePage` (via `settings.LMS_ROOT_URL`) and `name` (the identifier).
* **Metadata**: Maintained the `name` field as the username for display/reporting purposes.

## Technical Details
* The filter now safely navigates the `extrainfo` relationship using `getattr`.
* Uses `settings.LMS_ROOT_URL` as the `homePage` to ensure environment-specific consistency.
* The `objectType` is explicitly set to `Agent`.

## Impact
> [!CAUTION]
> Changing the IFI from `mbox` to `account` means that the LRS will treat these as new agents. Historical data tied to emails will not be automatically merged with these new records based on National ID/Username.

## Testing
- Verified that statements are emitted with the `account` property instead of `mbox`.

## Result in stage
<img width="814" height="664" alt="image" src="https://github.com/user-attachments/assets/4ae64fdc-27c2-43d8-97a5-0c404814f62d" />
