### PR TITLE
feat(api): implement ScopedRateThrottle for ProgramsListView

### DIFF
--- a/eox_nelp/programs/api/v1/views.py
+++ b/eox_nelp/programs/api/v1/views.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
+from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
 from eox_nelp.edxapp_wrapper.course_api import CourseDetailSerializer, CourseListView
@@ -168,6 +169,8 @@ class ProgramsListView(CourseListView):
     authentication_classes = [JwtAuthentication, SessionAuthenticationAllowInactiveUser]
     permission_classes = [IsAuthenticated, ProgramsLookupPermission]
     serializer_class = ProgramLookupSerializer
+    throttle_classes = (ScopedRateThrottle,)
+    throttle_scope = 'programs_lookup'
 
     @require_national_id_query_param()
     def get(self, request, *args, **kwargs):

--- a/eox_nelp/settings/common.py
+++ b/eox_nelp/settings/common.py
@@ -74,6 +74,8 @@ def plugin_settings(settings):
     if find_spec('eox_audit_model') and EOX_AUDIT_MODEL_APP not in settings.INSTALLED_APPS:
         settings.INSTALLED_APPS.append(EOX_AUDIT_MODEL_APP)
 
+    settings.REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['programs_lookup'] = '300/minute'
+
     try:
         payments_notifications_context = (
             'eox_nelp.payment_notifications.context_processor.payments_notifications_context'

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -123,6 +123,7 @@ REST_FRAMEWORK = {
         'user': '60/minute',
         'service_user': '800/minute',
         'registration_validation': '30/minute',
+        'programs_lookup': '300/minute',
     },
 }
 EVENT_TRACKING_ENABLED = True


### PR DESCRIPTION
## Description
This PR replaces the existing `CourseListUserThrottle` in `ProgramsListView` with DRF's `ScopedRateThrottle`. This change allows for more granular control over request limits specifically for the programs lookup endpoint without affecting the global course list throttling.

## Changes
- Modified `ProgramsListView` to include `ScopedRateThrottle` in its `throttle_classes`.
- Added `throttle_scope = 'programs_lookup'` to the view.
