### PR TITLE
perf(api): add 5-minute cache to mfe config endpoint

### DIFF
--- a/eox_nelp/mfe_config_api/v1/views.py
+++ b/eox_nelp/mfe_config_api/v1/views.py
@@ -4,6 +4,8 @@ import json
 
 from django.conf import settings
 from django.http import JsonResponse
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from eox_theming.configuration import ThemingConfiguration as theming
 from rest_framework import status
 
@@ -45,7 +47,7 @@ class NelpMFEConfigView(MFEConfigView):
     }
     ```
     """
-
+    @method_decorator(cache_page(settings.EOX_NELP_MFE_CONFIG_API_CACHE_TIMEOUT))
     def get(self, request):
         """
         Return the MFE configuration by NELP(adding custom nelp fields).

--- a/eox_nelp/settings/common.py
+++ b/eox_nelp/settings/common.py
@@ -60,6 +60,8 @@ def plugin_settings(settings):
     settings.EOX_NELP_DJANGO_COMMENT_COMMON_BACKEND = 'eox_nelp.edxapp_wrapper.backends.django_comment_common_r_v1'
     settings.EOX_NELP_CONTENTSTORE = 'eox_nelp.edxapp_wrapper.backends.contentstore_r_v1'
 
+    settings.EOX_NELP_MFE_CONFIG_API_CACHE_TIMEOUT = 300
+
     settings.FUTUREX_API_URL = 'https://testing-site.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'
     settings.FUTUREX_API_CLIENT_SECRET = 'my-test-client-secret'

--- a/eox_nelp/settings/test.py
+++ b/eox_nelp/settings/test.py
@@ -43,6 +43,8 @@ def test_plugin_settings(settings):  # pylint: disable=too-many-statements
     settings.EOX_NELP_DJANGO_COMMENT_COMMON_BACKEND = 'eox_nelp.edxapp_wrapper.test_backends.django_comment_common_r_v1'
     settings.EOX_NELP_CONTENTSTORE = 'eox_nelp.edxapp_wrapper.test_backends.contentstore_r_v1'
 
+    settings.EOX_NELP_MFE_CONFIG_API_CACHE_TIMEOUT = 300
+
     settings.FUTUREX_API_URL = 'https://testing.com'
     settings.FUTUREX_API_CLIENT_ID = 'my-test-client-id'
     settings.FUTUREX_API_CLIENT_SECRET = 'my-test-client-secret'


### PR DESCRIPTION
## Description
This PR introduces a caching layer to the `eox-nelp` MFE configuration API endpoint to optimize backend response times and eliminate redundant Python processing overhead.

Since the MFE frontend already caches this configuration locally for 5 minutes, aligning the backend view with a 300-second TTL prevents unnecessary CPU and serialization load without affecting the end-user experience.

## Changes
* Imported and applied `@method_decorator(cache_page(...))` to the `get` method in `mfe_config_api/v1/views.py`.
* Added the `EOX_NELP_MFE_CONFIG_API_CACHE_TIMEOUT = 300` setting to `common.py` and `test.py` to control the TTL centrally.

## Impact
* **Performance:** The MFE configuration response is now cached for 5 minutes, significantly reducing CPU processing, dictionary merging, and JSON serialization overhead during high-traffic login and load events.
* **Maintainability:** Relies on Django's native caching utilities, respecting current multitenant isolation out of the box.