### PR TITLE
Jlc/redis writting proxy course experience

### DIFF
--- a/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
+++ b/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
@@ -191,6 +191,7 @@ class ExperienceTestMixin:
         expected_data = self.base_data.copy()
         expected_data["data"]["attributes"].update(self.patch_data)
         expected_data["data"]["id"] = None # element by cache does not have id from db.
+
         response = self.client.patch(url_endpoint, self.patch_data, format="multipart")
 
         persist_experience_to_db_mock.delay.assert_called_once()

--- a/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
+++ b/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
@@ -182,6 +182,7 @@ class ExperienceTestMixin:
         Test a  patch  request to the detail endpoint for the desired view
         using form data (type document in browser).
         Expected behavior:
+            - persist_experience_to_db task is called once to persist the change to db.
             - Return expected content type.
             - Status code 200.
             - Check the response is equal to the expected patched.
@@ -195,7 +196,6 @@ class ExperienceTestMixin:
         persist_experience_to_db.delay.assert_called_once()
         self.assertIn(response.headers["Content-Type"], RESPONSE_CONTENT_TYPES)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        breakpoint()
         self.assertEqual(response.json(), expected_data)
 
     def test_block_url_object_regex(self):

--- a/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
+++ b/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
@@ -177,7 +177,7 @@ class ExperienceTestMixin:
 
     @override_settings(EOX_NELP_EXPERIENCE_CACHE_ENABLED=True)
     @patch("eox_nelp.course_experience.api.v1.views.persist_experience_to_db")
-    def test_patch_object_form_data_cache_on(self, persist_experience_to_db):
+    def test_patch_object_form_data_cache_on(self, persist_experience_to_db_mock):
         """
         Test a  patch  request to the detail endpoint for the desired view
         using form data (type document in browser).
@@ -193,7 +193,7 @@ class ExperienceTestMixin:
         expected_data["data"]["id"] = None # element by cache does not have id from db.
         response = self.client.patch(url_endpoint, self.patch_data, format="multipart")
 
-        persist_experience_to_db.delay.assert_called_once()
+        persist_experience_to_db_mock.delay.assert_called_once()
         self.assertIn(response.headers["Content-Type"], RESPONSE_CONTENT_TYPES)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), expected_data)
@@ -313,6 +313,32 @@ class UnitExperienceTestMixin(ExperienceTestMixin):
 
         response = self.client.post(url_endpoint, self.post_data, format="json", contentType="application/json")
 
+        self.assertIn(response.headers["Content-Type"], RESPONSE_CONTENT_TYPES)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["data"]["attributes"], expected_data["data"]["attributes"])
+        self.assertEqual(response.json()["data"]["relationships"], expected_data["data"]["relationships"])
+
+    @override_settings(EOX_NELP_EXPERIENCE_CACHE_ENABLED=True)
+    @patch("eox_nelp.course_experience.api.v1.views.persist_experience_to_db")
+    def test_post_item_id_with_cache_on(self, persist_experience_to_db_mock):
+        """
+        Test a  post  request to the list endpoint for the desired view.
+        Expected behavior:
+            - persist_experience_to_db task is called once to persist the change to db.
+            - Return expected content type.
+            - Status code 201.
+            - Check the response object item_id has the expected attributes field.
+            - Check the response object item_id has the expected relationships field.
+        """
+        url_endpoint = reverse(self.reverse_viewname_list)
+        expected_data = self.base_data.copy()
+        expected_data["data"]["attributes"].update(
+            {key: value for key, value in self.post_data.items() if key != "course_id"}
+        )
+
+        response = self.client.post(url_endpoint, self.post_data, format="json", contentType="application/json")
+
+        persist_experience_to_db_mock.delay.assert_called_once()
         self.assertIn(response.headers["Content-Type"], RESPONSE_CONTENT_TYPES)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.json()["data"]["attributes"], expected_data["data"]["attributes"])

--- a/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
+++ b/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
@@ -212,6 +212,28 @@ class UnitExperienceTestMixin(ExperienceTestMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), self.base_data)
 
+    @override_settings(EOX_NELP_EXPERIENCE_CACHE_ENABLED=True)
+    @patch("eox_nelp.course_experience.api.v1.views.ModelViewSet.get_object")
+    def test_get_specific_item_id_cached_on(self, mock_get_object):
+        """
+        Test a  get  request to the detail endpoint for the desired view.
+        Expected behavior:
+            - super get_object is not called because the object is retrieved from cache.
+            - Return expected content type.
+            - Status code 200.
+            - Match the response of item_id is eqal to the expected.
+        """
+
+        url_endpoint = reverse(self.reverse_viewname_detail, kwargs=self.object_url_kwarg)
+        expected_data = self.base_data.copy()
+        expected_data["data"]["id"] = None # element by cache does not have id from db.
+        response = self.client.get(url_endpoint)
+
+        mock_get_object.assert_not_called()
+        self.assertIn(response.headers["Content-Type"], RESPONSE_CONTENT_TYPES)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(response.json(), expected_data)
+
     def test_get_wrong_item_id(self):
         """
         Test a  get  request to the detail endpoint for units views.
@@ -373,9 +395,32 @@ class CourseExperienceTestMixin(ExperienceTestMixin):
         url_endpoint = reverse(self.reverse_viewname_detail, kwargs=self.object_url_kwarg)
 
         response = self.client.get(url_endpoint)
+
         self.assertIn(response.headers["Content-Type"], RESPONSE_CONTENT_TYPES)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), self.base_data)
+
+    @override_settings(EOX_NELP_EXPERIENCE_CACHE_ENABLED=True)
+    @patch("eox_nelp.course_experience.api.v1.views.ModelViewSet.get_object")
+    def test_get_specific_course_id_cached_on(self, mock_get_object):
+        """
+        Test a  get  request to the detail endpoint for the desired view.
+        Expected behavior:
+            - super get_object is not called because the object is retrieved from cache.
+            - Return expected content type.
+            - Status code 200.
+            - Match the response object_key with the object_id passed Using the  url.
+        """
+        url_endpoint = reverse(self.reverse_viewname_detail, kwargs=self.object_url_kwarg)
+        expected_data = self.base_data.copy()
+        expected_data["data"]["id"] = None # element by cache does not have id from
+
+        response = self.client.get(url_endpoint)
+
+        mock_get_object.assert_not_called()
+        self.assertIn(response.headers["Content-Type"], RESPONSE_CONTENT_TYPES)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), expected_data)
 
     def test_get_wrong_course_id(self):
         """

--- a/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
+++ b/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
@@ -175,6 +175,29 @@ class ExperienceTestMixin:
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), expected_data)
 
+    @override_settings(EOX_NELP_EXPERIENCE_CACHE_ENABLED=True)
+    @patch("eox_nelp.course_experience.api.v1.views.persist_experience_to_db")
+    def test_patch_object_form_data_cache_on(self, persist_experience_to_db):
+        """
+        Test a  patch  request to the detail endpoint for the desired view
+        using form data (type document in browser).
+        Expected behavior:
+            - Return expected content type.
+            - Status code 200.
+            - Check the response is equal to the expected patched.
+        """
+        url_endpoint = reverse(self.reverse_viewname_detail, kwargs=self.object_url_kwarg)
+        expected_data = self.base_data.copy()
+        expected_data["data"]["attributes"].update(self.patch_data)
+        expected_data["data"]["id"] = None # element by cache does not have id from db.
+        response = self.client.patch(url_endpoint, self.patch_data, format="multipart")
+
+        persist_experience_to_db.delay.assert_called_once()
+        self.assertIn(response.headers["Content-Type"], RESPONSE_CONTENT_TYPES)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        breakpoint()
+        self.assertEqual(response.json(), expected_data)
+
     def test_block_url_object_regex(self):
         """
         Test block a request to the detail endpoint for the desired view

--- a/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
+++ b/eox_nelp/course_experience/api/v1/tests/mixins_helpers.py
@@ -190,7 +190,7 @@ class ExperienceTestMixin:
         url_endpoint = reverse(self.reverse_viewname_detail, kwargs=self.object_url_kwarg)
         expected_data = self.base_data.copy()
         expected_data["data"]["attributes"].update(self.patch_data)
-        expected_data["data"]["id"] = None # element by cache does not have id from db.
+        expected_data["data"]["id"] = None  # element by cache does not have id from db.
 
         response = self.client.patch(url_endpoint, self.patch_data, format="multipart")
 
@@ -250,7 +250,7 @@ class UnitExperienceTestMixin(ExperienceTestMixin):
 
         url_endpoint = reverse(self.reverse_viewname_detail, kwargs=self.object_url_kwarg)
         expected_data = self.base_data.copy()
-        expected_data["data"]["id"] = None # element by cache does not have id from db.
+        expected_data["data"]["id"] = None  # element by cache does not have id from db.
         response = self.client.get(url_endpoint)
 
         mock_get_object.assert_not_called()
@@ -463,7 +463,7 @@ class CourseExperienceTestMixin(ExperienceTestMixin):
         """
         url_endpoint = reverse(self.reverse_viewname_detail, kwargs=self.object_url_kwarg)
         expected_data = self.base_data.copy()
-        expected_data["data"]["id"] = None # element by cache does not have id from
+        expected_data["data"]["id"] = None  # element by cache does not have id from
 
         response = self.client.get(url_endpoint)
 

--- a/eox_nelp/course_experience/api/v1/tests/test_views.py
+++ b/eox_nelp/course_experience/api/v1/tests/test_views.py
@@ -13,6 +13,7 @@ from eox_nelp.course_experience.models import (
     ReportCourse,
     ReportUnit,
 )
+from eox_nelp.course_experience.cache import set_experience_cache
 from eox_nelp.edxapp_wrapper.course_overviews import CourseOverview
 
 from .mixins_helpers import (
@@ -52,6 +53,10 @@ class LikeDislikeUnitExperienceTestCase(UnitExperienceTestMixin, APITestCase):
             author_id=self.user.id,
             status=False,
         )
+        set_experience_cache("LikeDislikeUnit", self.user.id, BASE_ITEM_ID, {
+            "status": self.my_unit_like.status,
+            "course_id": str(self.my_course.id),
+        })
         self.base_data = {
             "data": {
                 "type": "LikeDislikeUnit",
@@ -95,6 +100,10 @@ class ReportUnitExperienceTestCase(UnitExperienceTestMixin, APITestCase):
             author_id=self.user.id,
             reason="Sexual content",
         )
+        set_experience_cache("ReportUnit", self.user.id, BASE_ITEM_ID, {
+            "reason": self.my_unit_report.reason,
+            "course_id": str(self.my_course.id),
+        })
         self.base_data = {
             "data": {
                 "type": "ReportUnit",
@@ -153,6 +162,10 @@ class LikeDislikeCourseExperienceTestCase(CourseExperienceTestMixin, APITestCase
             author_id=self.user.id,
             status=False,
         )
+        set_experience_cache("LikeDislikeCourse", self.user.id, str(self.my_course), {
+            "status": self.my_course_like.status,
+            "course_id": str(self.my_course.id),
+        })
         self.object_url_kwarg = {self.object_key: BASE_COURSE_ID}
         # add another course due the post doesnt work without existent courseoverview
         self.my_new_course, _ = CourseOverview.objects.get_or_create(id=self.new_object_id)
@@ -195,6 +208,10 @@ class ReportCourseExperienceTestCase(CourseExperienceTestMixin, APITestCase):
             author_id=self.user.id,
             reason="Sexual content",
         )
+        set_experience_cache("ReportCourse", self.user.id, str(self.my_course), {
+            "reason": self.my_course_report.reason,
+            "course_id": str(self.my_course.id),
+        })
         self.object_url_kwarg = {self.object_key: BASE_COURSE_ID}
         self.my_new_course, _ = CourseOverview.objects.get_or_create(id=self.new_object_id)
         self.base_data = {
@@ -249,6 +266,13 @@ class FeedbackCourseExperienceTestCase(CourseExperienceTestMixin, APITestCase):
             public=True,
             recommended=False,
         )
+        set_experience_cache("FeedbackCourse", self.user.id, str(self.my_course), {
+            "feedback": self.my_course_feedback.feedback,
+            "rating_content": self.my_course_feedback.rating_content,
+            "rating_instructors": self.my_course_feedback.rating_instructors,
+            "public": self.my_course_feedback.public,
+            "recommended": self.my_course_feedback.recommended,
+        })
         self.object_url_kwarg = {self.object_key: BASE_COURSE_ID}
         self.my_new_course, _ = CourseOverview.objects.get_or_create(id=self.new_object_id)
         self.base_data = {

--- a/eox_nelp/course_experience/api/v1/tests/test_views.py
+++ b/eox_nelp/course_experience/api/v1/tests/test_views.py
@@ -13,7 +13,7 @@ from eox_nelp.course_experience.models import (
     ReportCourse,
     ReportUnit,
 )
-from eox_nelp.course_experience.cache import set_experience_cache
+from eox_nelp.course_experience.cache import upsert_experience_cache
 from eox_nelp.edxapp_wrapper.course_overviews import CourseOverview
 
 from .mixins_helpers import (
@@ -53,7 +53,7 @@ class LikeDislikeUnitExperienceTestCase(UnitExperienceTestMixin, APITestCase):
             author_id=self.user.id,
             status=False,
         )
-        set_experience_cache("LikeDislikeUnit", self.user.id, BASE_ITEM_ID, {
+        upsert_experience_cache("LikeDislikeUnit", self.user.id, BASE_ITEM_ID, {
             "status": self.my_unit_like.status,
             "course_id": str(self.my_course.id),
         })
@@ -100,7 +100,7 @@ class ReportUnitExperienceTestCase(UnitExperienceTestMixin, APITestCase):
             author_id=self.user.id,
             reason="Sexual content",
         )
-        set_experience_cache("ReportUnit", self.user.id, BASE_ITEM_ID, {
+        upsert_experience_cache("ReportUnit", self.user.id, BASE_ITEM_ID, {
             "reason": self.my_unit_report.reason,
             "course_id": str(self.my_course.id),
         })
@@ -162,7 +162,7 @@ class LikeDislikeCourseExperienceTestCase(CourseExperienceTestMixin, APITestCase
             author_id=self.user.id,
             status=False,
         )
-        set_experience_cache("LikeDislikeCourse", self.user.id, str(self.my_course), {
+        upsert_experience_cache("LikeDislikeCourse", self.user.id, str(self.my_course), {
             "status": self.my_course_like.status,
             "course_id": str(self.my_course.id),
         })
@@ -208,7 +208,7 @@ class ReportCourseExperienceTestCase(CourseExperienceTestMixin, APITestCase):
             author_id=self.user.id,
             reason="Sexual content",
         )
-        set_experience_cache("ReportCourse", self.user.id, str(self.my_course), {
+        upsert_experience_cache("ReportCourse", self.user.id, str(self.my_course), {
             "reason": self.my_course_report.reason,
             "course_id": str(self.my_course.id),
         })
@@ -266,7 +266,7 @@ class FeedbackCourseExperienceTestCase(CourseExperienceTestMixin, APITestCase):
             public=True,
             recommended=False,
         )
-        set_experience_cache("FeedbackCourse", self.user.id, str(self.my_course), {
+        upsert_experience_cache("FeedbackCourse", self.user.id, str(self.my_course), {
             "feedback": self.my_course_feedback.feedback,
             "rating_content": self.my_course_feedback.rating_content,
             "rating_instructors": self.my_course_feedback.rating_instructors,

--- a/eox_nelp/course_experience/api/v1/tests/test_views.py
+++ b/eox_nelp/course_experience/api/v1/tests/test_views.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from eox_nelp.course_experience.cache import upsert_experience_cache
 from eox_nelp.course_experience.models import (
     FeedbackCourse,
     LikeDislikeCourse,
@@ -13,7 +14,6 @@ from eox_nelp.course_experience.models import (
     ReportCourse,
     ReportUnit,
 )
-from eox_nelp.course_experience.cache import upsert_experience_cache
 from eox_nelp.edxapp_wrapper.course_overviews import CourseOverview
 
 from .mixins_helpers import (

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -217,10 +217,11 @@ class ExperienceView(BaseJsonAPIView):
     def update_create_experience_cache(self, serializer):
         kind, target = self._get_kind_and_target()
         value = serializer.validated_data.copy()
+        value.update(self.request.parser_context["kwargs"])
+        value.pop("author", None)
+        value = {k: str(v) for k, v in value.items()}
         target_id = value.get(target)
         user_id = self.request.user.id
-        value.pop("author", None)
-        value["course_id"] = str(value["course_id"])
         set_experience_cache(kind, user_id, target_id, value)
         persist_experience_to_db.delay(kind, user_id, target_id, value)
 

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -34,6 +34,7 @@ from rest_framework_json_api.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework_json_api.schemas.openapi import AutoSchema
 from rest_framework_json_api.views import ModelViewSet, ReadOnlyModelViewSet
 
+from eox_nelp.course_experience.cache import get_experience_cache, is_experience_cache_enabled, set_experience_cache
 from eox_nelp.course_experience.models import (
     FeedbackCourse,
     LikeDislikeCourse,
@@ -42,7 +43,6 @@ from eox_nelp.course_experience.models import (
     ReportUnit,
 )
 from eox_nelp.course_experience.tasks import persist_experience_to_db
-from eox_nelp.course_experience.cache import is_experience_cache_enabled, get_experience_cache, set_experience_cache
 from eox_nelp.edxapp_wrapper.site_configuration import configuration_helpers
 
 from .filters import FeedbackCourseFieldsFilter
@@ -122,7 +122,7 @@ class ExperienceView(BaseJsonAPIView):
             cached = get_experience_cache(kind, user_id, target_id)
             if cached is not None:
                 model_class = self.get_serializer().Meta.model
-                model_fields = {f.name for f in model_class._meta.fields}
+                model_fields = {f.name for f in model_class._meta.fields}  # pylint: disable=protected-access
                 instance_data = {k: v for k, v in cached.items() if k in model_fields}
                 instance_data["course_id_id"] = instance_data.pop("course_id", None)
                 instance_data["author_id"] = user_id
@@ -189,7 +189,7 @@ class ExperienceView(BaseJsonAPIView):
             request.data["author"] = f'{{"type": "User", "id": "{request.user.id}"}}'
         return request
 
-    def _get_kind_and_target(self, data=None, kwargs=None):
+    def _get_kind_and_target(self):
         """
         Infer kind and target_id using resource_name and lookup_field.
         """
@@ -216,6 +216,7 @@ class ExperienceView(BaseJsonAPIView):
         super().perform_update(serializer)
 
     def update_create_experience_cache(self, serializer):
+        """Update the cache with the new experience data and schedule a task to persist it to the database."""
         kind, target = self._get_kind_and_target()
         value = serializer.validated_data.copy()
         value.update(self.request.parser_context["kwargs"])
@@ -225,6 +226,7 @@ class ExperienceView(BaseJsonAPIView):
         user_id = self.request.user.id
         set_experience_cache(kind, user_id, target_id, value)
         persist_experience_to_db.delay(kind, user_id, target_id, value)
+
 
 class UnitExperienceView(ExperienceView):
     """Class with  Experience view for units.

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -114,20 +114,31 @@ class ExperienceView(BaseJsonAPIView):
             super().get_queryset(*args, **kwargs).filter(author_id=self.request.user.id).order_by('id'),
         )
 
+    def create_memory_instance(self, cached_value, target, target_id, user_id):
+        """Create a memory instance of the experience data. This is used when cache is enabled.
+
+        Args:
+            cached_value: The cached value of the experience data.
+            target: The target field for the experience.
+            target_id: The ID of the target.
+            user_id: The ID of the user.
+        """
+        model_class = self.get_serializer().Meta.model
+        model_fields = {f.name for f in model_class._meta.fields}  # pylint: disable=protected-access
+        instance_data = {k: v for k, v in cached_value.items() if k in model_fields}
+        instance_data[target] = target_id
+        instance_data["course_id_id"] = instance_data.pop("course_id", None)
+        instance_data["author_id"] = user_id
+        return model_class(**instance_data)
+
     def get_object(self):
         if is_experience_cache_enabled():
             kind, target = self._get_kind_and_target()
             target_id = self.request.parser_context["kwargs"][target]
             user_id = self.request.user.id
-            cached = get_experience_cache(kind, user_id, target_id)
-            if cached:
-                model_class = self.get_serializer().Meta.model
-                model_fields = {f.name for f in model_class._meta.fields}  # pylint: disable=protected-access
-                instance_data = {k: v for k, v in cached.items() if k in model_fields}
-                instance_data[target] = target_id
-                instance_data["course_id_id"] = instance_data.pop("course_id", None)
-                instance_data["author_id"] = user_id
-                return model_class(**instance_data)
+            cached_value = get_experience_cache(kind, user_id, target_id)
+            if cached_value:
+                return self.create_memory_instance(cached_value, target, target_id, user_id)
         try:
             return super().get_object()
         except InvalidKeyError as exc:
@@ -212,7 +223,6 @@ class ExperienceView(BaseJsonAPIView):
         """Handle the update of an existing experience. Use cache if enabled, otherwise save to DB."""
         if is_experience_cache_enabled():
             self.update_create_experience_cache(serializer)
-            return
         # Only save to DB if cache is disabled
         super().perform_update(serializer)
 
@@ -225,6 +235,8 @@ class ExperienceView(BaseJsonAPIView):
         value = {k: str(v) for k, v in value.items()}
         target_id = value.get(target)
         user_id = self.request.user.id
+
+        setattr(self.serializer, "instance", self.create_memory_instance(value, target, target_id, user_id))
         set_experience_cache(kind, user_id, target_id, value)
         persist_experience_to_db.delay(kind, user_id, target_id, value)
 

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -200,6 +200,7 @@ class ExperienceView(BaseJsonAPIView):
             kind, target_id = self._get_kind_and_target()
             user_id = self.request.user.id
             value = serializer.validated_data.copy()
+            value["course_id"] = str(value["course_id"])
             value.pop("author", None)
             set_experience_cache(kind, user_id, target_id, value)
             persist_experience_to_db.delay(kind, user_id, target_id, value)

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -116,7 +116,8 @@ class ExperienceView(BaseJsonAPIView):
 
     def get_object(self):
         if is_experience_cache_enabled():
-            kind, target_id = self._get_kind_and_target()
+            kind, target = self._get_kind_and_target()
+            target_id = self.request.parser_context["kwargs"][target]
             user_id = self.request.user.id
             cached = get_experience_cache(kind, user_id, target_id)
             if cached is not None:

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -41,6 +41,8 @@ from eox_nelp.course_experience.models import (
     ReportCourse,
     ReportUnit,
 )
+from eox_nelp.course_experience.tasks import persist_experience_to_db
+from eox_nelp.course_experience.cache import is_experience_cache_enabled, get_experience_cache, set_experience_cache
 from eox_nelp.edxapp_wrapper.site_configuration import configuration_helpers
 
 from .filters import FeedbackCourseFieldsFilter
@@ -113,6 +115,13 @@ class ExperienceView(BaseJsonAPIView):
         )
 
     def get_object(self):
+        if is_experience_cache_enabled():
+            kind, target_id = self._get_kind_and_target()
+            user_id = self.request.user.id
+            cached = get_experience_cache(kind, user_id, target_id)
+            if cached is not None:
+                # You may want to adapt this to your serializer/response format
+                return cached
         try:
             return super().get_object()
         except InvalidKeyError as exc:
@@ -174,6 +183,42 @@ class ExperienceView(BaseJsonAPIView):
         else:
             request.data["author"] = f'{{"type": "User", "id": "{request.user.id}"}}'
         return request
+
+    def _get_kind_and_target(self, data=None, kwargs=None):
+        """
+        Infer kind and target_id using resource_name and lookup_field.
+        """
+        kind = getattr(self, "resource_name", None)
+        target_id = getattr(self, "lookup_field", None)
+        if not kind or not target_id:
+            raise ValueError("resource_name and lookup_field must be defined in the view.")
+        return kind, target_id
+
+    def perform_create(self, serializer):
+        """Handle the creation of a new experience. Use cache if enabled, otherwise save to DB."""
+        if is_experience_cache_enabled():
+            kind, target_id = self._get_kind_and_target()
+            user_id = self.request.user.id
+            value = serializer.validated_data.copy()
+            value.pop("author", None)
+            set_experience_cache(kind, user_id, target_id, value)
+            persist_experience_to_db.delay(kind, user_id, target_id, value)
+            return
+        # Only save to DB if cache is disabled
+        super().perform_create(serializer)
+
+    def perform_update(self, serializer):
+        """Handle the update of an existing experience. Use cache if enabled, otherwise save to DB."""
+        if is_experience_cache_enabled():
+            kind, target_id = self._get_kind_and_target()
+            user_id = self.request.user.id
+            value = serializer.validated_data.copy()
+            value.pop("author", None)
+            set_experience_cache(kind, user_id, target_id, value)
+            persist_experience_to_db.delay(kind, user_id, target_id, value)
+            return
+        # Only save to DB if cache is disabled
+        super().perform_update(serializer)
 
 
 class UnitExperienceView(ExperienceView):

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -34,7 +34,7 @@ from rest_framework_json_api.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework_json_api.schemas.openapi import AutoSchema
 from rest_framework_json_api.views import ModelViewSet, ReadOnlyModelViewSet
 
-from eox_nelp.course_experience.cache import get_experience_cache, is_experience_cache_enabled, set_experience_cache
+from eox_nelp.course_experience.cache import get_experience_cache, is_experience_cache_enabled, upsert_experience_cache
 from eox_nelp.course_experience.models import (
     FeedbackCourse,
     LikeDislikeCourse,
@@ -237,9 +237,9 @@ class ExperienceView(BaseJsonAPIView):
         target_id = value.get(target)
         user_id = self.request.user.id
 
-        setattr(serializer, "instance", self.create_memory_instance(value, target, target_id, user_id))
-        set_experience_cache(kind, user_id, target_id, value)
+        value = upsert_experience_cache(kind, user_id, target_id, value)
         persist_experience_to_db.delay(kind, user_id, target_id, value)
+        setattr(serializer, "instance", self.create_memory_instance(value, target, target_id, user_id))
 
 
 class UnitExperienceView(ExperienceView):

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -120,10 +120,11 @@ class ExperienceView(BaseJsonAPIView):
             target_id = self.request.parser_context["kwargs"][target]
             user_id = self.request.user.id
             cached = get_experience_cache(kind, user_id, target_id)
-            if cached is not None:
+            if cached:
                 model_class = self.get_serializer().Meta.model
                 model_fields = {f.name for f in model_class._meta.fields}  # pylint: disable=protected-access
                 instance_data = {k: v for k, v in cached.items() if k in model_fields}
+                instance_data[target] = target_id
                 instance_data["course_id_id"] = instance_data.pop("course_id", None)
                 instance_data["author_id"] = user_id
                 return model_class(**instance_data)

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -25,7 +25,6 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.filters import SearchFilter
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 from rest_framework_json_api.django_filters import DjangoFilterBackend
 from rest_framework_json_api.filters import OrderingFilter, QueryParameterValidationFilter
 from rest_framework_json_api.metadata import JSONAPIMetadata
@@ -149,9 +148,6 @@ class ExperienceView(BaseJsonAPIView):
             The return of ancestor create method with the request after processing.
         """
         request = self.change_author_data_2_request_user(request)
-        if is_experience_cache_enabled():
-            partial = kwargs.pop('partial', False)
-            return Response(self.update_create_experience_cache(request, partial))
         try:
             return super().create(request, *args, **kwargs)
         except InvalidKeyError as exc:
@@ -172,9 +168,6 @@ class ExperienceView(BaseJsonAPIView):
             The return of ancestor update method with the request after processing.
         """
         request = self.change_author_data_2_request_user(request)
-        if is_experience_cache_enabled():
-            partial = kwargs.pop('partial', False)
-            return Response(self.update_create_experience_cache(request, partial))
         try:
             return super().update(request, *args, **kwargs)
         except InvalidKeyError as exc:
@@ -207,26 +200,33 @@ class ExperienceView(BaseJsonAPIView):
             raise ValueError("resource_name and lookup_field must be defined in the view.")
         return kind, target
 
-    def update_create_experience_cache(self, request, partial):
-        """Update the cache with the new experience data and schedule a task to persist it to the database."""
+    def perform_create(self, serializer):
+        """Handle the creation of a new experience. Use cache if enabled, otherwise save to DB."""
+        if is_experience_cache_enabled():
+            self.update_create_experience_cache(serializer)
+            return
+        # Only save to DB if cache is disabled
+        super().perform_create(serializer)
 
-        instance = self.get_object()
-        for k, v in request.data.items():
-            if k not in ["author", "course_id", "item_id"]:
-                setattr(instance, k, v)
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
-        serializer.is_valid(raise_exception=True)
-        value = serializer.validated_data.copy()
+    def perform_update(self, serializer):
+        """Handle the update of an existing experience. Use cache if enabled, otherwise save to DB."""
+        if is_experience_cache_enabled():
+            self.update_create_experience_cache(serializer)
+            return
+        # Only save to DB if cache is disabled
+        super().perform_update(serializer)
+
+    def update_create_experience_cache(self, serializer):
+        """Update the cache with the new experience data and schedule a task to persist it to the database."""
         kind, target = self._get_kind_and_target()
+        value = serializer.validated_data.copy()
+        value.update(self.request.parser_context.get("kwargs", {}))
         value.pop("author", None)
         value = {k: str(v) for k, v in value.items()}
-        user_id = self.request.user.id
         target_id = value.get(target)
-
+        user_id = self.request.user.id
         set_experience_cache(kind, user_id, target_id, value)
         persist_experience_to_db.delay(kind, user_id, target_id, value)
-
-        return serializer.data
 
 
 class UnitExperienceView(ExperienceView):

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -25,6 +25,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.filters import SearchFilter
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework_json_api.django_filters import DjangoFilterBackend
 from rest_framework_json_api.filters import OrderingFilter, QueryParameterValidationFilter
 from rest_framework_json_api.metadata import JSONAPIMetadata
@@ -168,6 +169,9 @@ class ExperienceView(BaseJsonAPIView):
             The return of ancestor update method with the request after processing.
         """
         request = self.change_author_data_2_request_user(request)
+        if is_experience_cache_enabled():
+            partial = kwargs.pop('partial', False)
+            return Response(self.update_create_experience_cache(request, partial))
         try:
             return super().update(request, *args, **kwargs)
         except InvalidKeyError as exc:
@@ -208,25 +212,28 @@ class ExperienceView(BaseJsonAPIView):
         # Only save to DB if cache is disabled
         super().perform_create(serializer)
 
-    def perform_update(self, serializer):
-        """Handle the update of an existing experience. Use cache if enabled, otherwise save to DB."""
-        if is_experience_cache_enabled():
-            self.update_create_experience_cache(serializer)
-            return
-        # Only save to DB if cache is disabled
-        super().perform_update(serializer)
 
-    def update_create_experience_cache(self, serializer):
+    def update_create_experience_cache(self, request, partial):
         """Update the cache with the new experience data and schedule a task to persist it to the database."""
-        kind, target = self._get_kind_and_target()
+
+        instance = self.get_object()
+        for k, v in request.data.items():
+            if k not in ["author", "course_id", "item_id"]:
+                setattr(instance, k, v)
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
         value = serializer.validated_data.copy()
+        kind, target = self._get_kind_and_target()
         value.update(self.request.parser_context["kwargs"])
         value.pop("author", None)
         value = {k: str(v) for k, v in value.items()}
-        target_id = value.get(target)
         user_id = self.request.user.id
+        target_id = value.get(target)
+
         set_experience_cache(kind, user_id, target_id, value)
         persist_experience_to_db.delay(kind, user_id, target_id, value)
+
+        return serializer.data
 
 
 class UnitExperienceView(ExperienceView):

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -224,7 +224,6 @@ class ExperienceView(BaseJsonAPIView):
         serializer.is_valid(raise_exception=True)
         value = serializer.validated_data.copy()
         kind, target = self._get_kind_and_target()
-        value.update(self.request.parser_context["kwargs"])
         value.pop("author", None)
         value = {k: str(v) for k, v in value.items()}
         user_id = self.request.user.id

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -149,6 +149,9 @@ class ExperienceView(BaseJsonAPIView):
             The return of ancestor create method with the request after processing.
         """
         request = self.change_author_data_2_request_user(request)
+        if is_experience_cache_enabled():
+            partial = kwargs.pop('partial', False)
+            return Response(self.update_create_experience_cache(request, partial))
         try:
             return super().create(request, *args, **kwargs)
         except InvalidKeyError as exc:
@@ -203,15 +206,6 @@ class ExperienceView(BaseJsonAPIView):
         if not kind or not target:
             raise ValueError("resource_name and lookup_field must be defined in the view.")
         return kind, target
-
-    def perform_create(self, serializer):
-        """Handle the creation of a new experience. Use cache if enabled, otherwise save to DB."""
-        if is_experience_cache_enabled():
-            self.update_create_experience_cache(serializer)
-            return
-        # Only save to DB if cache is disabled
-        super().perform_create(serializer)
-
 
     def update_create_experience_cache(self, request, partial):
         """Update the cache with the new experience data and schedule a task to persist it to the database."""

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -223,6 +223,7 @@ class ExperienceView(BaseJsonAPIView):
         """Handle the update of an existing experience. Use cache if enabled, otherwise save to DB."""
         if is_experience_cache_enabled():
             self.update_create_experience_cache(serializer)
+            return
         # Only save to DB if cache is disabled
         super().perform_update(serializer)
 

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -236,7 +236,7 @@ class ExperienceView(BaseJsonAPIView):
         target_id = value.get(target)
         user_id = self.request.user.id
 
-        setattr(self.serializer, "instance", self.create_memory_instance(value, target, target_id, user_id))
+        setattr(serializer, "instance", self.create_memory_instance(value, target, target_id, user_id))
         set_experience_cache(kind, user_id, target_id, value)
         persist_experience_to_db.delay(kind, user_id, target_id, value)
 

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -193,21 +193,15 @@ class ExperienceView(BaseJsonAPIView):
         Infer kind and target_id using resource_name and lookup_field.
         """
         kind = getattr(self, "resource_name", None)
-        target_id = getattr(self, "lookup_field", None)
-        if not kind or not target_id:
+        target = getattr(self, "lookup_field", None)
+        if not kind or not target:
             raise ValueError("resource_name and lookup_field must be defined in the view.")
-        return kind, target_id
+        return kind, target
 
     def perform_create(self, serializer):
         """Handle the creation of a new experience. Use cache if enabled, otherwise save to DB."""
         if is_experience_cache_enabled():
-            kind, target_id = self._get_kind_and_target()
-            user_id = self.request.user.id
-            value = serializer.validated_data.copy()
-            value["course_id"] = str(value["course_id"])
-            value.pop("author", None)
-            set_experience_cache(kind, user_id, target_id, value)
-            persist_experience_to_db.delay(kind, user_id, target_id, value)
+            self.update_create_experience_cache(serializer)
             return
         # Only save to DB if cache is disabled
         super().perform_create(serializer)
@@ -215,16 +209,20 @@ class ExperienceView(BaseJsonAPIView):
     def perform_update(self, serializer):
         """Handle the update of an existing experience. Use cache if enabled, otherwise save to DB."""
         if is_experience_cache_enabled():
-            kind, target_id = self._get_kind_and_target()
-            user_id = self.request.user.id
-            value = serializer.validated_data.copy()
-            value.pop("author", None)
-            set_experience_cache(kind, user_id, target_id, value)
-            persist_experience_to_db.delay(kind, user_id, target_id, value)
+            self.update_create_experience_cache(serializer)
             return
         # Only save to DB if cache is disabled
         super().perform_update(serializer)
 
+    def update_create_experience_cache(self, serializer):
+        kind, target = self._get_kind_and_target()
+        value = serializer.validated_data.copy()
+        target_id = value.get(target)
+        user_id = self.request.user.id
+        value.pop("author", None)
+        value["course_id"] = str(value["course_id"])
+        set_experience_cache(kind, user_id, target_id, value)
+        persist_experience_to_db.delay(kind, user_id, target_id, value)
 
 class UnitExperienceView(ExperienceView):
     """Class with  Experience view for units.

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -120,8 +120,12 @@ class ExperienceView(BaseJsonAPIView):
             user_id = self.request.user.id
             cached = get_experience_cache(kind, user_id, target_id)
             if cached is not None:
-                # You may want to adapt this to your serializer/response format
-                return cached
+                model_class = self.get_serializer().Meta.model
+                model_fields = {f.name for f in model_class._meta.fields}
+                instance_data = {k: v for k, v in cached.items() if k in model_fields}
+                instance_data["course_id_id"] = instance_data.pop("course_id", None)
+                instance_data["author_id"] = user_id
+                return model_class(**instance_data)
         try:
             return super().get_object()
         except InvalidKeyError as exc:

--- a/eox_nelp/course_experience/cache.py
+++ b/eox_nelp/course_experience/cache.py
@@ -1,6 +1,8 @@
-from django.core.cache import cache
-from django.conf import settings
+"""Utility functions for caching user experience data (likes, feedback, reports) in Django cache framework."""
 import json
+
+from django.conf import settings
+from django.core.cache import cache
 
 
 def is_experience_cache_enabled():

--- a/eox_nelp/course_experience/cache.py
+++ b/eox_nelp/course_experience/cache.py
@@ -26,12 +26,14 @@ def set_experience_cache(kind, user_id, target_id, value):
         getattr(settings, "EOX_NELP_EXPERIENCE_CACHE_TTL", 7200),  # 2 hours default
     )
 
+
 def upsert_experience_cache(kind, user_id, target_id, value):
     """Safely set experience, only changing new values and keeping old keys."""
     existing_data = get_experience_cache(kind, user_id, target_id) or {}
     existing_data.update(value)
     set_experience_cache(kind, user_id, target_id, existing_data)
     return existing_data
+
 
 def get_experience_cache(kind, user_id, target_id):
     """Get experience data from cache."""

--- a/eox_nelp/course_experience/cache.py
+++ b/eox_nelp/course_experience/cache.py
@@ -26,6 +26,12 @@ def set_experience_cache(kind, user_id, target_id, value):
         getattr(settings, "EOX_NELP_EXPERIENCE_CACHE_TTL", 7200),  # 2 hours default
     )
 
+def upsert_experience_cache(kind, user_id, target_id, value):
+    """Safely set experience, only changing new values and keeping old keys."""
+    existing_data = get_experience_cache(kind, user_id, target_id) or {}
+    existing_data.update(value)
+    set_experience_cache(kind, user_id, target_id, existing_data)
+    return existing_data
 
 def get_experience_cache(kind, user_id, target_id):
     """Get experience data from cache."""

--- a/eox_nelp/course_experience/cache.py
+++ b/eox_nelp/course_experience/cache.py
@@ -2,24 +2,35 @@ from django.core.cache import cache
 from django.conf import settings
 import json
 
-CACHE_TTL = getattr(settings, "EOX_NELP_EXPERIENCE_CACHE_TTL", 7200)  # 2 hours default
 
-def experience_key(kind, user_id, target_id):
+def is_experience_cache_enabled():
+    """Check if experience caching is enabled via Django settings."""
+    return getattr(settings, "EOX_NELP_EXPERIENCE_CACHE_ENABLED", False)
+
+
+def experience_cache_key(kind, user_id, target_id):
     """
     kind: 'like', 'feedback', 'report', etc.
     target_id: item_id or course_id (string or int)
     """
     return f"experience:{kind}:{user_id}:{target_id}"
 
-def set_experience(kind, user_id, target_id, value):
-    """Set experience data in cache."""
-    cache.set(experience_key(kind, user_id, target_id), json.dumps(value), CACHE_TTL)
 
-def get_experience(kind, user_id, target_id):
+def set_experience_cache(kind, user_id, target_id, value):
+    """Set experience data in cache."""
+    cache.set(
+        experience_cache_key(kind, user_id, target_id),
+        json.dumps(value),
+        getattr(settings, "EOX_NELP_EXPERIENCE_CACHE_TTL", 7200),  # 2 hours default
+    )
+
+
+def get_experience_cache(kind, user_id, target_id):
     """Get experience data from cache."""
-    val = cache.get(experience_key(kind, user_id, target_id))
+    val = cache.get(experience_cache_key(kind, user_id, target_id))
     return json.loads(val) if val is not None else None
 
-def delete_experience(kind, user_id, target_id):
+
+def delete_experience_cache(kind, user_id, target_id):
     """Delete experience data from cache."""
-    cache.delete(experience_key(kind, user_id, target_id))
+    cache.delete(experience_cache_key(kind, user_id, target_id))

--- a/eox_nelp/course_experience/cache.py
+++ b/eox_nelp/course_experience/cache.py
@@ -17,7 +17,6 @@ def experience_cache_key(kind, user_id, target_id):
 
 
 def set_experience_cache(kind, user_id, target_id, value):
-    value["course_id"] = str(value["course_id"])
     """Set experience data in cache."""
     cache.set(
         experience_cache_key(kind, user_id, target_id),

--- a/eox_nelp/course_experience/cache.py
+++ b/eox_nelp/course_experience/cache.py
@@ -1,0 +1,25 @@
+from django.core.cache import cache
+from django.conf import settings
+import json
+
+CACHE_TTL = getattr(settings, "EOX_NELP_EXPERIENCE_CACHE_TTL", 7200)  # 2 hours default
+
+def experience_key(kind, user_id, target_id):
+    """
+    kind: 'like', 'feedback', 'report', etc.
+    target_id: item_id or course_id (string or int)
+    """
+    return f"experience:{kind}:{user_id}:{target_id}"
+
+def set_experience(kind, user_id, target_id, value):
+    """Set experience data in cache."""
+    cache.set(experience_key(kind, user_id, target_id), json.dumps(value), CACHE_TTL)
+
+def get_experience(kind, user_id, target_id):
+    """Get experience data from cache."""
+    val = cache.get(experience_key(kind, user_id, target_id))
+    return json.loads(val) if val is not None else None
+
+def delete_experience(kind, user_id, target_id):
+    """Delete experience data from cache."""
+    cache.delete(experience_key(kind, user_id, target_id))

--- a/eox_nelp/course_experience/cache.py
+++ b/eox_nelp/course_experience/cache.py
@@ -17,6 +17,7 @@ def experience_cache_key(kind, user_id, target_id):
 
 
 def set_experience_cache(kind, user_id, target_id, value):
+    value["course_id"] = str(value["course_id"])
     """Set experience data in cache."""
     cache.set(
         experience_cache_key(kind, user_id, target_id),

--- a/eox_nelp/course_experience/tasks.py
+++ b/eox_nelp/course_experience/tasks.py
@@ -1,0 +1,35 @@
+from celery import shared_task
+from django.contrib.auth import get_user_model
+from .models import LikeDislikeUnit, LikeDislikeCourse, FeedbackUnit, FeedbackCourse, ReportUnit, ReportCourse
+
+User = get_user_model()
+
+
+@shared_task
+def persist_experience_to_db(kind, user_id, target_id, value):
+    """Persist experience data to the database. This is intended to be called asynchronously after updating cache."""
+    user = User.objects.get(id=user_id)
+    model_map = {
+        "like_unit": LikeDislikeUnit,
+        "like_course": LikeDislikeCourse,
+        "feedback_unit": FeedbackUnit,
+        "feedback_course": FeedbackCourse,
+        "report_unit": ReportUnit,
+        "report_course": ReportCourse,
+    }
+    model = model_map.get(kind)
+    if not model:
+        return
+
+    # Prepare filter and defaults based on kind
+    filter_kwargs = {"author": user}
+    if "unit" in kind:
+        filter_kwargs["item_id"] = target_id
+    else:
+        filter_kwargs["course_id"] = target_id
+
+    # Save or update
+    model.objects.update_or_create(
+        defaults=value,
+        **filter_kwargs
+    )

--- a/eox_nelp/course_experience/tasks.py
+++ b/eox_nelp/course_experience/tasks.py
@@ -1,7 +1,9 @@
+"""Celery tasks for asynchronously persisting experience data to the database."""
 import logging
 
 from celery import shared_task
-from .models import LikeDislikeUnit, LikeDislikeCourse, FeedbackUnit, FeedbackCourse, ReportUnit, ReportCourse
+
+from .models import FeedbackCourse, FeedbackUnit, LikeDislikeCourse, LikeDislikeUnit, ReportCourse, ReportUnit
 
 logger = logging.getLogger(__name__)
 
@@ -10,7 +12,8 @@ logger = logging.getLogger(__name__)
 def persist_experience_to_db(kind, user_id, target_id, value):
     """Persist experience data to the database. This is intended to be called asynchronously after updating cache."""
     logger.info(
-        f"[persist_experience_to_db] kind={kind}, user_id={user_id}, target_id={target_id}, value={value}"
+        "[persist_experience_to_db] kind=%s, user_id=%s, target_id=%s, value=%s",
+        kind, user_id, target_id, value,
     )
     model_map = {
         "LikeDislikeUnit": LikeDislikeUnit,
@@ -22,7 +25,7 @@ def persist_experience_to_db(kind, user_id, target_id, value):
     }
     model = model_map.get(kind)
     if not model:
-        logger.warning(f"[persist_experience_to_db] Unknown kind: {kind}")
+        logger.warning("[persist_experience_to_db] Unknown kind: %s", kind)
         return
 
     # Prepare filter and defaults based on kind

--- a/eox_nelp/course_experience/tasks.py
+++ b/eox_nelp/course_experience/tasks.py
@@ -1,33 +1,37 @@
+import logging
+
 from celery import shared_task
-from django.contrib.auth import get_user_model
 from .models import LikeDislikeUnit, LikeDislikeCourse, FeedbackUnit, FeedbackCourse, ReportUnit, ReportCourse
 
-User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 @shared_task
 def persist_experience_to_db(kind, user_id, target_id, value):
     """Persist experience data to the database. This is intended to be called asynchronously after updating cache."""
-    user = User.objects.get(id=user_id)
+    logger.info(
+        f"[persist_experience_to_db] kind={kind}, user_id={user_id}, target_id={target_id}, value={value}"
+    )
     model_map = {
-        "like_unit": LikeDislikeUnit,
-        "like_course": LikeDislikeCourse,
-        "feedback_unit": FeedbackUnit,
-        "feedback_course": FeedbackCourse,
-        "report_unit": ReportUnit,
-        "report_course": ReportCourse,
+        "LikeDislikeUnit": LikeDislikeUnit,
+        "LikeDislikeCourse": LikeDislikeCourse,
+        "FeedbackUnit": FeedbackUnit,
+        "FeedbackCourse": FeedbackCourse,
+        "ReportUnit": ReportUnit,
+        "ReportCourse": ReportCourse,
     }
     model = model_map.get(kind)
     if not model:
+        logger.warning(f"[persist_experience_to_db] Unknown kind: {kind}")
         return
 
     # Prepare filter and defaults based on kind
-    filter_kwargs = {"author": user}
-    if "unit" in kind:
+    filter_kwargs = {"author_id": user_id}
+    if "Unit" in kind:
         filter_kwargs["item_id"] = target_id
     else:
-        filter_kwargs["course_id"] = target_id
-
+        filter_kwargs["course_id_id"] = target_id
+    value["course_id_id"] = value.pop("course_id", None)
     # Save or update
     model.objects.update_or_create(
         defaults=value,

--- a/eox_nelp/course_experience/tests/test_cache.py
+++ b/eox_nelp/course_experience/tests/test_cache.py
@@ -1,0 +1,74 @@
+"""Unit tests for the course_experience.cache utilities.
+
+This module verifies cache enablement flag handling and CRUD/merge
+behaviour for experience cache helpers using patched cache and settings.
+"""
+import json
+from unittest.mock import patch
+
+from eox_nelp.course_experience import cache as cache_module
+
+
+class TestCacheUtilities:
+    """Test the cache utility functions for experience caching, including enablement flag and CRUD operations."""
+    storage = {}
+
+    def setup_method(self):
+        """Setup common test data."""
+        # pylint: disable=attribute-defined-outside-init
+        self.kind = "feedback"
+        self.user_id = 42
+        self.target_id = "course-abc"
+        self.key = cache_module.experience_cache_key(self.kind, self.user_id, self.target_id)
+        self.storage.clear()  # reset fake cache storage before each test
+
+    def fake_set(self, key, value, ttl=None):  # pylint: disable=unused-argument
+        """Fake cache set method that stores values in a dict."""
+        self.storage[key] = value
+
+    def fake_get(self, key):
+        """Fake cache get method that retrieves values from the dict."""
+        return self.storage.get(key)
+
+    def fake_delete(self, key):
+        """Fake cache delete method that removes values from the dict."""
+        self.storage.pop(key, None)
+
+    @patch("eox_nelp.course_experience.cache.settings")
+    def test_is_experience_cache_enabled_true_and_false(self, mock_settings):
+        """Test that the cache enablement flag is correctly read from settings."""
+        mock_settings.EOX_NELP_EXPERIENCE_CACHE_ENABLED = True
+        assert cache_module.is_experience_cache_enabled() is True
+
+        mock_settings.EOX_NELP_EXPERIENCE_CACHE_ENABLED = False
+        assert cache_module.is_experience_cache_enabled() is False
+
+    @patch("eox_nelp.course_experience.cache.cache")
+    def test_set_get_delete_experience_cache(self, mock_cache):
+        """Test that setting, getting, and deleting experience cache works as expected."""
+        mock_cache.set.side_effect = self.fake_set
+        mock_cache.get.side_effect = self.fake_get
+        mock_cache.delete.side_effect = self.fake_delete
+
+        value = {"rated": 5}
+        cache_module.set_experience_cache(self.kind, self.user_id, self.target_id, value)
+        # cache stores JSON string; get_experience_cache decodes it
+        assert cache_module.get_experience_cache(self.kind, self.user_id, self.target_id) == value
+
+        cache_module.delete_experience_cache(self.kind, self.user_id, self.target_id)
+        assert cache_module.get_experience_cache(self.kind, self.user_id, self.target_id) is None
+
+    @patch("eox_nelp.course_experience.cache.cache")
+    def test_upsert_experience_cache_merges_values(self, mock_cache):
+        """Test that upsert merges incoming values with existing cached object."""
+        # pre-existing stored JSON
+        existing = {"a": 1, "b": 2}
+        self.storage[self.key] = json.dumps(existing)
+        mock_cache.set.side_effect = self.fake_set
+        mock_cache.get.side_effect = self.fake_get
+
+        result = cache_module.upsert_experience_cache(self.kind, self.user_id, self.target_id, {"b": 20, "c": 3})
+
+        assert result == {"a": 1, "b": 20, "c": 3}
+        # stored value should be the merged JSON string
+        assert json.loads(self.storage[self.key]) == result

--- a/eox_nelp/course_experience/tests/test_tasks.py
+++ b/eox_nelp/course_experience/tests/test_tasks.py
@@ -1,0 +1,57 @@
+"""Unit tests for course_experience.tasks.
+
+Validates mapping from kind to model and the update_or_create call
+behaviour for both Course and Unit kinds, and ensures unknown kinds are logged.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from eox_nelp.course_experience import tasks
+
+
+class TestPersistExperienceToDB:
+    """Test the persist_experience_to_db task for correct model mapping and update_or_create behaviour."""
+    def setup_method(self):
+        """Setup common test data."""
+        # pylint: disable=attribute-defined-outside-init
+        self.user_id = 7
+        self.target_id = "course-xyz"
+        # include course_id in payload to exercise pop/assignment logic
+        self.value = {"course_id": "course-1", "comment": "ok"}
+        # minimal fake model with objects.update_or_create spy
+        self.fake_model = SimpleNamespace(objects=MagicMock())
+
+    @patch("eox_nelp.course_experience.tasks.FeedbackCourse")
+    def test_persist_course_kind_calls_update_or_create(self, mock_model):
+        """Test that FeedbackCourse kind results in update_or_create call with course_id_id."""
+        mock_model.return_value = self.fake_model
+        # patch the class reference to our fake model object
+        # call with a copy because function mutates the dict passed in
+        tasks.persist_experience_to_db("FeedbackCourse", self.user_id, self.target_id, self.value.copy())
+
+        expected_defaults = {"course_id_id": "course-1", "comment": "ok"}
+        mock_model.objects.update_or_create.assert_called_once_with(
+            defaults=expected_defaults, author_id=self.user_id, course_id_id=self.target_id
+        )
+
+    @patch("eox_nelp.course_experience.tasks.LikeDislikeUnit")
+    def test_persist_unit_kind_calls_update_or_create_with_item_id(self, mock_model):
+        """Test that LikeDislikeUnit kind results in update_or_create call with item_id."""
+        mock_model.return_value = self.fake_model
+        kind = "LikeDislikeUnit"
+        target_item = "item-123"
+        value = {"course_id": "course-1", "score": 1}
+
+        tasks.persist_experience_to_db(kind, self.user_id, target_item, value.copy())
+
+        expected_defaults = {"course_id_id": "course-1", "score": 1}
+        mock_model.objects.update_or_create.assert_called_once_with(
+            defaults=expected_defaults, author_id=self.user_id, item_id=target_item
+        )
+
+    @patch("eox_nelp.course_experience.tasks.logger")
+    def test_unknown_kind_logs_warning_and_returns(self, mock_logger):
+        """Test that an unknown kind results in a warning log and no database call."""
+        tasks.persist_experience_to_db("NonExistingKind", 1, "t", {})
+
+        mock_logger.warning.assert_called_once()


### PR DESCRIPTION

## feat(course_experience): add cache-backed read/write proxy for experience API

### Summary
- Introduces a cache-backed proxy path in the ExperienceView that, when enabled, serves reads from cache and writes to cache (with asynchronous persistence to DB).
- Aims to improve responsiveness for read-after-write scenarios by returning an in-memory instance immediately while persisting changes to the database via a Celery task.

#### What changed
- views.py
  - get_object: if EOX_NELP_EXPERIENCE_CACHE_ENABLED is True, attempt to read the cached entry (get_experience_cache) and return an in-memory model instance (create_memory_instance) instead of hitting the DB.
  - perform_create / perform_update: when cache flag is enabled, short-circuit DB save and call update_create_experience_cache.
  - update_create_experience_cache: merge serializer.validated_data with parser_context kwargs, drop author, stringify values, upsert into cache via upsert_experience_cache, enqueue persist_experience_to_db.delay(...) and set serializer.instance to an in-memory model instance built from cached data.

#### Rationale
- Provide immediate read-after-write behavior for API clients without waiting for synchronous DB writes.
- Offload write-heavy operations to asynchronous workers and reduce load on primary DB in write bursts.

#### Behavioral details & implications
- When the feature flag is enabled:
  - POST/PATCH operations update cache and schedule async persistence; the API returns an in-memory instance that reflects the change immediately.
  - GET operations for a specific resource will return cached data if present.
- When the flag is disabled: existing synchronous DB read/write behavior remains unchanged.
- The change casts all cached values to strings before storing; this may affect downstream consumers expecting typed values.
- Asynchronous persistence is fire-and-forget (persist_experience_to_db.delay). If Celery/worker failures occur, cache changes may not reach DB.

Configuration
- Toggle feature with Django setting: EOX_NELP_EXPERIENCE_CACHE_ENABLED (bool).
- Requires cache backend and Celery workers configured for full functionality.

Backward compatibility & safety
- Default behavior unchanged when the flag is False.
- Serializer.instance is set to an in-memory model instance (not persisted yet) — callers that rely on DB identity should be aware of eventual consistency window.

Testing / QA suggestions
- Unit tests:
  - verify get_object returns memory instance when cache contains entry and flag enabled.
  - verify perform_create/perform_update call update_create_experience_cache and schedule persist_experience_to_db.delay when flag enabled.
  - verify normal DB flow is used when flag disabled.
  - validate handling of missing target_id and that no task is scheduled in that case.
- Integration:
  - End-to-end test with cache + Celery worker verifying eventual DB persistence.
  - Load test to validate DB load reduction and worker throughput.

Potential follow-ups / improvements
- Make cache helper functions (get/set/upsert/delete) themselves respect EOX_NELP_EXPERIENCE_CACHE_ENABLED to centrali

ze flag handling (reduces chances of inconsistent use).
- Avoid casting all values to str; only cast fields that require string form (ids), preserving numeric/boolean types.
- Add error handling/retries/monitoring for persist_experience_to_db tasks to avoid silent data loss.
- Add metrics/tracing around cache hits, misses, queued persistence, and task failures.

#### How to test locally
- Enable the feature in local settings:
  - EOX_NELP_EXPERIENCE_CACHE_ENABLED = True
- Run tests and manual API checks:
  - pytest eox_nelp/course_experience/tests -q
  - Post a item with like and dislike.
  Using cache view it was saved.

<img width="1396" height="89" alt="2026-05-28_14-59" src="https://github.com/user-attachments/assets/5fc7a453-7b2c-43bd-a847-a36387f652cd" />
<img width="943" height="201" alt="2026-05-28_15-08" src="https://github.com/user-attachments/assets/a35d8a3f-4f73-4fd1-a7d1-dc664e300096" />
View the item, which was also saved in db using django admin.
<img width="1568" height="130" alt="2026-05-28_15-13" src="https://github.com/user-attachments/assets/da696547-c373-4068-bed1-25036fb0fd56" />

**Test cache persistence with get**.
Delete the item in django.
The api would return the object, since exists yet in cache.

[Screencast from 28-05-26 15:44:10.webm](https://github.com/user-attachments/assets/dbe1a769-c2cf-4214-a7ee-d2525541e34e)


Files changed
- views.py (primary)

If you want, I can prepare:
- a short unit-test checklist or example tests for the new paths,
- a small patch to make cache helpers honor the feature flag, or
- a rollback/feature-flagging plan to mitigate risks.

**Jira story**: https://edunext.atlassian.net/browse/FUTUREX-1753?atlOrigin=eyJpIjoiMWExZmVmODU3MDlmNDdkYmJmM2Y3YTdjOGJmYzM5OTMiLCJwIjoiaiJ9