### PR TITLE
Jlc/non atomic course experience

### DIFF
--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -14,9 +14,11 @@ Classes:
         - PublicFeedbackCourseExperienceView: class-view(`/eox-nelp/api/experience/v1/feedback/public/courses/`)
 """
 from django.conf import settings
+from django.db import transaction
 from django.db.models import Q
 from django.http import Http404
 from django.http.request import QueryDict
+from django.utils.decorators import method_decorator
 from edx_django_utils.db.read_replica import use_read_replica_if_available
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
@@ -95,6 +97,7 @@ class BaseJsonAPIView(ModelViewSet):
     search_param = "filter[search]"
 
 
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
 class ExperienceView(BaseJsonAPIView):
     """Class to set functionality of an ExperienceView.
 

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -15,7 +15,6 @@ Classes:
 """
 from django.conf import settings
 from django.db import transaction
-from django.db import connection
 from django.db.models import Q
 from django.http import Http404
 from django.http.request import QueryDict
@@ -118,7 +117,6 @@ class ExperienceView(BaseJsonAPIView):
 
     def get_object(self):
         try:
-            print(f"Is inside atomic block: {connection.in_atomic_block}")
             return super().get_object()
         except InvalidKeyError as exc:
             raise Http404 from exc
@@ -138,7 +136,6 @@ class ExperienceView(BaseJsonAPIView):
             The return of ancestor create method with the request after processing.
         """
         request = self.change_author_data_2_request_user(request)
-        print(f"\nIs inside atomic block: {connection.in_atomic_block}")
         try:
             return super().create(request, *args, **kwargs)
         except InvalidKeyError as exc:

--- a/eox_nelp/course_experience/api/v1/views.py
+++ b/eox_nelp/course_experience/api/v1/views.py
@@ -15,6 +15,7 @@ Classes:
 """
 from django.conf import settings
 from django.db import transaction
+from django.db import connection
 from django.db.models import Q
 from django.http import Http404
 from django.http.request import QueryDict
@@ -117,6 +118,7 @@ class ExperienceView(BaseJsonAPIView):
 
     def get_object(self):
         try:
+            print(f"Is inside atomic block: {connection.in_atomic_block}")
             return super().get_object()
         except InvalidKeyError as exc:
             raise Http404 from exc
@@ -136,6 +138,7 @@ class ExperienceView(BaseJsonAPIView):
             The return of ancestor create method with the request after processing.
         """
         request = self.change_author_data_2_request_user(request)
+        print(f"\nIs inside atomic block: {connection.in_atomic_block}")
         try:
             return super().create(request, *args, **kwargs)
         except InvalidKeyError as exc:


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->




# perf(course_experience): use non-atomic requests to reduce DB lock waits



Summary
- Reduce database lock contention and long lock-wait times on the Course Experience API by handling request lifecycle outside an automatic DB transaction for affected views.

Inspired in courseware.
https://github.com/openedx/openedx-platform/blob/b1b59ddc5a7d8af31091c74d1f3b75ff38acde3e/lms/djangoapps/courseware/views/views.py#L1437

https://stackoverflow.com/questions/49880358/db-inserts-in-a-django-app-gradually-get-slower-as-more-inserts-are-executed

What changed
- Apply non-atomic request handling to Course/Unit experience views so create/update operations are executed without being wrapped in an automatic transaction at the view-dispatch level.
  - Primary change: transaction.non_atomic_requests decorator applied to ExperienceView dispatch (eox_nelp/course_experience/api/v1/views.py).
- No model or schema changes; behavior remains functionally equivalent except for transaction scope.

Rationale
- Synchronous DB transactions spanning entire request processing can extend lock hold times and increase lock wait errors under load.
- Marking the outer request as non-atomic reduces lock hold duration for short-lived write operations and allows finer-grained transaction management where needed (e.g., via explicit transaction.atomic blocks around critical DB writes).
- This change aims to improve throughput and reduce latency for concurrent write-heavy workloads on the experience endpoints.

Behavioral impacts & risks
- Requests will no longer be implicitly wrapped in a global transaction. Code relying on the implicit request-scoped atomicity may need explicit transaction.atomic blocks to maintain invariants.
- Potential for partial updates if code does not explicitly manage transactions where multiple DB operations must succeed atomically.
- Likely reduction in lock wait time and improved request throughput for high concurrency scenarios.

Operational considerations
- Verify Celery or async persistence flows (if present) still maintain data consistency — move transactional guarantees into worker tasks or explicit atomic blocks when required.
- Add monitoring for:
  - DB lock waits/errors
  - API error rates for create/update endpoints
  - End-to-end data consistency metrics

Testing / QA
-  checkout to commit [8bd6b1b](https://github.com/nelc/eox-nelp/pull/313/commits/8bd6b1b9126e4f059182d261e984a1b0b95c07b4)
  then view logs of a course experienve view that you inside in an atomic request using the conection.
<img width="1557" height="451" alt="image" src="https://github.com/user-attachments/assets/f440a7f3-287c-4c6d-a352-96b70da3b33b" />

<img width="1607" height="342" alt="image" src="https://github.com/user-attachments/assets/a98241ab-45d8-4753-854c-5a025fb44da0" />


 then comment the decorator and you could check you are not in a atomic view.

```python3
#@method_decorator(transaction.non_atomic_requests, name='dispatch')
```



<img width="1588" height="537" alt="image" src="https://github.com/user-attachments/assets/7f1a6927-8dd9-436b-b360-8700e6657748" />



<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
