### PR TITLE
feat: rm with atomit due setting

### DIFF
--- a/eox_nelp/user_profile/api/v1/views.py
+++ b/eox_nelp/user_profile/api/v1/views.py
@@ -12,7 +12,6 @@ Available Views:
 import logging
 
 from django.conf import settings
-from django.db import transaction
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from rest_framework import status
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
@@ -55,11 +54,10 @@ def update_user_data(request):
     ```
     """
     try:
-        with transaction.atomic():
-            user = request.user
-            data = request.data
-            update_account(user, data)
-            update_extrainfo(user, data)
+        user = request.user
+        data = request.data
+        update_account(user, data)
+        update_extrainfo(user, data)
     except errors.AccountValidationError as err:
         return Response({"field_errors": err.field_errors}, status=status.HTTP_400_BAD_REQUEST)
     except errors.AccountUpdateError as err:


### PR DESCRIPTION

# Description


As edx-platform has django `ATOMIC_REQUESTS` set to true, this is not necessary



This is a proposal to test to improve the behaviour of the auth user locked table.

<img width="1902" height="1020" alt="image" src="https://github.com/user-attachments/assets/47952e83-9195-44b5-9501-f61a6b246e99" />


https://www.stanza.dev/courses/django-orm-mastery/transactions/django-orm-mastery-savepoints
https://medium.com/@moosaabdullahi45/safe-guide-to-realiable-database-operations-using-django-atomic-transactions-10c89da5f5aa
https://forum.djangoproject.com/t/ability-to-skip-nested-transactions/4826/2